### PR TITLE
add option for "elastic timeout" to define timeout period as a percent of previous builds duration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,4 +25,13 @@
     <developerConnection>scm:git:git@github.com:jenkinsci/build-timeout-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/build-timeout-plugin</url>
   </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.8.5</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -1,5 +1,7 @@
 package hudson.plugins.build_timeout;
 
+import static hudson.util.TimeUnit2.MILLISECONDS;
+import static hudson.util.TimeUnit2.MINUTES;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -8,14 +10,21 @@ import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.Executor;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.triggers.SafeTimerTask;
 import hudson.triggers.Trigger;
+import hudson.util.TimeUnit2;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * {@link BuildWrapper} that terminates a build if it's taking too long.
@@ -23,6 +32,13 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Kohsuke Kawaguchi
  */
 public class BuildTimeoutWrapper extends BuildWrapper {
+    
+    protected static final int NUMBER_OF_BUILDS_TO_AVERAGE = 3;
+    public static long MINIMUM_TIMEOUT_MILLISECONDS = Long.getLong(BuildTimeoutWrapper.class.getName()+ ".MINIMUM_TIMEOUT_MILLISECONDS", 3 * 60 * 1000);
+
+    
+    public static final String ABSOLUTE = "absolute";
+    public static final String ELASTIC = "elastic";
     /**
      * If the build took longer than this amount of minutes,
      * it will be terminated.
@@ -33,15 +49,38 @@ public class BuildTimeoutWrapper extends BuildWrapper {
      * Fail the build rather than aborting it
      */
     public boolean failBuild;
+
+    /**
+     * The percentage of the mean of the duration of the last n successful builds
+     * to wait before killing the build.
+     * 
+     * IE, if the last n successful builds averaged a 10 minute duration,
+     * then 200% of that would be 20 minutes.
+     */
+    public int timeoutPercentage;
+    
+    /**
+     * Values can be "elastic" or "absolute"
+     */
+    public String timeoutType;
+    
+    /**
+     * The timeout to use if there are no valid builds in the build 
+     * history (ie, no successful or unstable builds)
+     */
+    public Integer timeoutMinutesElasticDefault;
     
     @DataBoundConstructor
-    public BuildTimeoutWrapper(int timeoutMinutes, boolean failBuild) {
+    public BuildTimeoutWrapper(int timeoutMinutes, boolean failBuild, int timeoutPercentage, int timeoutMinutesElasticDefault, String timeoutType) {
+        this.timeoutPercentage = timeoutPercentage;
         this.timeoutMinutes = Math.max(3,timeoutMinutes);
+        this.timeoutMinutesElasticDefault = Math.max(3, timeoutMinutesElasticDefault);
         this.failBuild = failBuild;
+        this.timeoutType = timeoutType;
     }
     
     @Override
-    public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
+    public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener) {
         class EnvironmentImpl extends Environment {
             final class TimeoutTimerTask extends SafeTimerTask {
                 private final AbstractBuild build;
@@ -56,10 +95,11 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
                 public void doRun() {
                     // timed out
-                    if (failBuild)
-                        listener.getLogger().println("Build timed out (after " + timeoutMinutes + " minutes). Marking the build as failed.");
-                    else
-                        listener.getLogger().println("Build timed out (after " + timeoutMinutes + " minutes). Marking the build as aborted.");
+                    long effectiveTimeoutMinutes = MINUTES.convert(effectiveTimeout,MILLISECONDS);
+                    if (failBuild) {
+                        listener.getLogger().println("Build timed out (after " + effectiveTimeoutMinutes + " minutes). Marking the build as failed.");
+                    } else
+                        listener.getLogger().println("Build timed out (after " + effectiveTimeoutMinutes + " minutes). Marking the build as aborted.");
                     timeout=true;
                     Executor e = build.getExecutor();
                     if (e != null)
@@ -69,9 +109,12 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
             private final TimeoutTimerTask task;
             
+            private final long effectiveTimeout;
+            
             public EnvironmentImpl() {
                 task = new TimeoutTimerTask(build, listener);
-                Trigger.timer.schedule(task, timeoutMinutes*60L*1000L );
+                this.effectiveTimeout = getEffectiveTimeout(timeoutMinutes * 60*1000, timeoutPercentage, timeoutMinutesElasticDefault * 60*1000, timeoutType, build.getProject().getBuilds()); 
+                Trigger.timer.schedule(task, effectiveTimeout);
             }
 
             @Override
@@ -84,6 +127,47 @@ public class BuildTimeoutWrapper extends BuildWrapper {
         return new EnvironmentImpl();
     }
 
+    public static long getEffectiveTimeout(int timeoutMilliseconds, int timeoutPercentage, int timeoutMillsecondsElasticDefault,
+            String timeoutType, List<Run> builds) {
+        
+        if (ELASTIC.equals(timeoutType)) {
+            double elasticTimeout = getElasticTimeout(timeoutPercentage, builds);
+            if (elasticTimeout == 0) {
+                return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, timeoutMillsecondsElasticDefault);
+            } else {
+                return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, elasticTimeout);    
+            }
+        } else {
+            return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, timeoutMilliseconds);    
+        }
+    }
+    
+    private static double getElasticTimeout(int timeoutPercentage, List<Run> builds) {
+        return timeoutPercentage * .01D * (timeoutPercentage > 0 ? averageDuration(builds) : 0);
+    }
+
+    private static double averageDuration(List <Run> builds) {
+        int nonFailingBuilds = 0;
+        int durationSum= 0;
+        
+        for (int i = builds.size() - 1; i >= 0 && nonFailingBuilds < NUMBER_OF_BUILDS_TO_AVERAGE; i--) {
+            Run run = builds.get(i);
+            if (run.getResult() != null && 
+                    run.getResult().isBetterOrEqualTo(Result.UNSTABLE)) {
+                durationSum += run.getDuration();
+                nonFailingBuilds++;
+            }
+        }
+        
+        return nonFailingBuilds > 0 ? durationSum / nonFailingBuilds : 0;
+    }
+
+    protected Object readResolve() {
+        if (timeoutType == null)  {
+            timeoutType = ABSOLUTE;
+        }
+        return this;
+    }
     
     @Override
     public Descriptor<BuildWrapper> getDescriptor() {
@@ -106,5 +190,25 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             return true;
         }
 
+        public int[] getPercentages() {
+            return new int[] {150,200,250,300,350,400};
+        }
+        
+        @Override
+        public BuildWrapper newInstance(StaplerRequest req, JSONObject formData)
+                throws hudson.model.Descriptor.FormException {
+            JSONObject timeoutObject = formData.getJSONObject("timeoutType");
+            
+            // we would ideally do this on the form itself (to show the default)
+            //but there is a show/hide bug when using radioOptions inside an optionBlock
+            if (timeoutObject.isNullObject() || timeoutObject.isEmpty()) {
+                formData.put("timeoutType", ELASTIC);
+            } else {
+                formData.put("timeoutType", timeoutObject.getString("value"));
+            }
+            
+            return super.newInstance(req, formData);
+        }
+        
     }
 }

--- a/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
@@ -1,7 +1,21 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Timeout minutes}" help="/plugin/build-timeout/help-projectConfig.html">
-    <f:textbox name="build-timeout.timeoutMinutes" value="${instance.timeoutMinutes}" />
-  </f:entry>
+  <f:radioBlock name="build-timeout.timeoutType" value="absolute" title="${%Absolute}" checked="${instance.timeoutType=='absolute'}">
+	  <f:entry title="${%Timeout minutes}" help="/plugin/build-timeout/help-projectConfig.html">
+	    <f:textbox name="build-timeout.timeoutMinutes" value="${instance.timeoutMinutes}" />
+	  </f:entry>
+  </f:radioBlock>
+  <f:radioBlock name="build-timeout.timeoutType" value="elastic" title="${%Elastic}" checked="${instance.timeoutType=='elastic'}">
+	  <f:entry title="${%Timeout as a percentage of recent non-failing builds}" help="/plugin/build-timeout/help-percentageTimeout.html">
+	   <select name="build-timeout.timeoutPercentage">
+	     <j:forEach var="percentage" items="${descriptor.percentages}">
+	        <f:option value="${percentage}" selected="${percentage==instance.timeoutPercentage}">${percentage == 0 ? 'None' : percentage + '%'}</f:option>
+	     </j:forEach>
+	   </select>
+	  </f:entry>
+	  <f:entry title="${%Timeout minutes if no successful or unstable builds}" help="/plugin/build-timeout/help-projectConfig.html">
+        <f:textbox name="build-timeout.timeoutMinutesElasticDefault" value="${instance.timeoutMinutesElasticDefault == null ? 60 : instance.timeoutMinutesElasticDefault}" />
+      </f:entry> 
+  </f:radioBlock>
    <f:entry title="${%Fail the build}" help="/plugin/build-timeout/help-failConfig.html">
       <f:checkbox name="build-timeout.failBuild" checked="${instance.failBuild}"/>
    </f:entry>

--- a/src/main/webapp/help-percentageTimeout.html
+++ b/src/main/webapp/help-percentageTimeout.html
@@ -1,0 +1,5 @@
+<div>
+    If the build duration lasts longer than this percentage of the three most recent non-failing builds, 
+    the build will be terminated and marked as aborted.  If there are no successful builds, the 
+    "Timeout minutes if no successful or unstable builds" field will be used instead.
+</div>

--- a/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperTest.java
@@ -1,0 +1,108 @@
+package hudson.plugins.build_timeout;
+import static hudson.model.Result.SUCCESS;
+import hudson.model.AbstractProject;
+import hudson.model.DependencyGraph;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.util.DescribableList;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.mockito.Mockito;
+
+
+public class BuildTimeoutWrapperTest extends TestCase {
+    
+
+    
+    private class Build extends Run {
+        int duration;
+        Result result;
+        public Build(int duration, Result result) throws IOException {
+            super(Mockito.mock(FreeStyleProject.class));
+            this.duration = duration;
+            this.result = result;
+        }
+        
+        @Override
+        public long getDuration() {
+            return duration;
+        }
+        
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+    }
+    private int timeoutPercentage = 0;
+    private int timeoutMilliseconds = 0;
+    private int timeoutMillisecondsElasticDefault = 0;
+    private Run[] historicalBuilds;
+    private String timeoutType = BuildTimeoutWrapper.ABSOLUTE;
+    private static final int MINIMUM = 60;
+
+
+    public void setUp() throws Exception {
+        super.setUp();
+        BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = MINIMUM;
+        this.historicalBuilds = new Build[] {};
+        timeoutPercentage = 0;
+        timeoutMilliseconds = 0;
+        timeoutMillisecondsElasticDefault = 0;
+        timeoutType = BuildTimeoutWrapper.ABSOLUTE;
+    }
+    
+    public void testDefaultTimeout() throws Exception {
+        assertEffectiveTimeout(MINIMUM, "Default timeout should abort the build.");
+        
+    }
+
+    public void testShorterThanMinimumLongerThanRequestedMinutes() throws Exception {
+        this.timeoutMilliseconds = 5;
+        assertEffectiveTimeout(MINIMUM, "Minimum overrides requested timeout");
+    }
+    
+    public void testPercentageWithOneBuild() throws Exception {
+        this.timeoutPercentage = 200;
+        this.timeoutMillisecondsElasticDefault = 30;
+        this.timeoutType = BuildTimeoutWrapper.ELASTIC;
+        this.historicalBuilds = new Build[] {new Build(60, SUCCESS)};
+        assertEffectiveTimeout(120, "Timeout should be 200% of 60");
+    } 
+    
+    public void testPercentageWithOneBuildLessThanDefault() throws Exception {
+        this.timeoutPercentage = 200;
+        this.timeoutMillisecondsElasticDefault = 30;
+        this.timeoutType = BuildTimeoutWrapper.ELASTIC;
+        this.historicalBuilds = new Build[] {new Build(10, SUCCESS)};
+        assertEffectiveTimeout(MINIMUM, "Timeout should be minimum");
+    } 
+
+    public void testPercentageWithTwoBuilds() throws Exception {
+        this.timeoutPercentage = 200;
+        this.timeoutType = BuildTimeoutWrapper.ELASTIC;
+        this.historicalBuilds = new Build[] {new Build(20, SUCCESS), new Build(40, SUCCESS)};
+        assertEffectiveTimeout(60, "Timeout should be 200% of the average of 20 and 40");
+    }
+    
+    public void testPercentageWithNoBuilds() throws Exception {
+        this.timeoutPercentage = 200;
+        this.timeoutMillisecondsElasticDefault = 90;
+        this.timeoutType = BuildTimeoutWrapper.ELASTIC;
+        assertEffectiveTimeout(90, "Timeout should be the elastic default.");
+    }
+
+    private void assertEffectiveTimeout(long expectedTimeout, String message)
+            throws IOException, Exception {
+        
+        Assert.assertEquals(expectedTimeout, BuildTimeoutWrapper.getEffectiveTimeout(this.timeoutMilliseconds, this.timeoutPercentage, this.timeoutMillisecondsElasticDefault, this.timeoutType, Arrays.asList(historicalBuilds)));
+    }
+    
+
+}


### PR DESCRIPTION
From custom fork used at CloudBees, contributed back to community
