### PR TITLE
JENKINS-12744 - Execute a command before timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,10 @@
       <version>1.8.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -4,29 +4,33 @@ import static hudson.util.TimeUnit2.MILLISECONDS;
 import static hudson.util.TimeUnit2.MINUTES;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.BuildListener;
 import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Executor;
+import hudson.model.Queue;
+import hudson.model.Run;
 import hudson.model.queue.Executables;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
-import hudson.tasks.Shell;
 import hudson.triggers.SafeTimerTask;
 import hudson.triggers.Trigger;
-import hudson.util.ListBoxModel;
 import hudson.util.TimeUnit2;
+import hudson.util.ListBoxModel;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.InputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.BufferedReader;
-import java.lang.ProcessBuilder;
+import java.util.List;
 
 import net.sf.json.JSONObject;
 
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -36,15 +40,15 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Kohsuke Kawaguchi
  */
 public class BuildTimeoutWrapper extends BuildWrapper {
-    
+
     protected static final int NUMBER_OF_BUILDS_TO_AVERAGE = 3;
     public static long MINIMUM_TIMEOUT_MILLISECONDS = Long.getLong(BuildTimeoutWrapper.class.getName()+ ".MINIMUM_TIMEOUT_MILLISECONDS", 3 * 60 * 1000);
 
-    
+
     public static final String ABSOLUTE = "absolute";
     public static final String ELASTIC = "elastic";
     public static final String STUCK = "likelyStuck";
-    
+
     /**
      * If the build took longer than this amount of minutes,
      * it will be terminated.
@@ -56,7 +60,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
      */
     public boolean failBuild;
 
-    
+
     /**
      * Writing the build description when timeout occurred.
      */
@@ -65,23 +69,23 @@ public class BuildTimeoutWrapper extends BuildWrapper {
     /**
      * The percentage of the mean of the duration of the last n successful builds
      * to wait before killing the build.
-     * 
+     *
      * IE, if the last n successful builds averaged a 10 minute duration,
      * then 200% of that would be 20 minutes.
      */
     public int timeoutPercentage;
-    
+
     /**
      * Values can be "elastic" or "absolute"
      */
     public String timeoutType;
-    
+
     /**
-     * The timeout to use if there are no valid builds in the build 
+     * The timeout to use if there are no valid builds in the build
      * history (ie, no successful or unstable builds)
      */
     public Integer timeoutMinutesElasticDefault;
-    
+
     public String timeoutAction;
 
     @DataBoundConstructor
@@ -96,7 +100,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
         this.timeoutType = timeoutType;
         this.timeoutAction = timeoutAction;
     }
-    
+
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException {
         class EnvironmentImpl extends Environment {
@@ -133,45 +137,59 @@ public class BuildTimeoutWrapper extends BuildWrapper {
                     timeout=true;
                     Executor e = build.getExecutor();
                     if (e != null)
-                        ExecuteTimeoutAction();
+                        executeTimeoutAction();
                         e.interrupt(failBuild? Result.FAILURE : Result.ABORTED);
                 }
             }
 
-            private void ExecuteTimeoutAction() {
-                if ((timeoutAction == null) || (timeoutAction.trim().equals(""))) {
+            private void executeTimeoutAction() {
+                if (StringUtils.isEmpty(timeoutAction)) {
                     return;
                 }
-                if (System.getProperty("os.name").startsWith("Win")) {
-                    listener.getLogger().println("Timeout actions are not supported on Windows");
-                    return;
-                }
-                listener.getLogger().println("Executing timeout action: " + timeoutAction);
+                listener.getLogger().println(
+                        "Executing timeout action: " + timeoutAction);
+                BufferedReader br = null;
+                File tmpShell = null;
+                ProcessBuilder pb;
                 try {
-                    File tmpShell = File.createTempFile("jenkins", ".sh");
+                    if (System.getProperty("os.name").toLowerCase().startsWith(
+                            "win")) {
+                        tmpShell = File.createTempFile("jenkins", ".bat");
+                        pb = new ProcessBuilder("cmd", "/c",
+                                tmpShell.getAbsolutePath());
+                    } else {
+                        tmpShell = File.createTempFile("jenkins", ".sh");
+                        pb = new ProcessBuilder("/bin/bash",
+                                tmpShell.getAbsolutePath());
+                    }
                     FileWriter tmpShellWriter = new FileWriter(tmpShell);
                     tmpShellWriter.write(timeoutAction);
                     tmpShellWriter.close();
-                    ProcessBuilder pb = new ProcessBuilder("/bin/bash", tmpShell.getAbsolutePath());
                     pb.redirectErrorStream(true);
                     Process p = pb.start();
-                    InputStream is = p.getInputStream();
-                    InputStreamReader isr = new InputStreamReader(is);
-                    BufferedReader br = new BufferedReader(isr);
+                    br = new BufferedReader(new InputStreamReader(
+                            p.getInputStream()));
                     String line;
                     while ((line = br.readLine()) != null) {
                         listener.getLogger().println(line);
                     }
+                    p.waitFor();
                 } catch (IOException e) {
-                    listener.getLogger().println("Error while trying to execute timeout action:");
-                    listener.getLogger().println(e.toString());
+                    listener.getLogger().println(
+                            "Error while trying to execute timeout action: "
+                                    + e.getMessage());
+                } catch (InterruptedException e) {
+                    listener.getLogger().println(e.getMessage());
+                } finally {
+                    IOUtil.close(br);
+                    tmpShell.delete();
                 }
             }
 
             private final TimeoutTimerTask task;
-            
+
             private final long effectiveTimeout;
-            
+
             public EnvironmentImpl() {
                 long timeout;
                 if (ELASTIC.equals(timeoutType)) {
@@ -190,7 +208,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
             /**
              * Get the time considered it stuck.
-             * 
+             *
              * @return 10 times as much as eta if eta is available, else 24 hours.
              * @see Executor#isLikelyStuck()
              */
@@ -225,19 +243,19 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
     public static long getEffectiveTimeout(long timeoutMilliseconds, int timeoutPercentage, int timeoutMillsecondsElasticDefault,
             String timeoutType, List<Run> builds) {
-        
+
         if (ELASTIC.equals(timeoutType)) {
             double elasticTimeout = getElasticTimeout(timeoutPercentage, builds);
             if (elasticTimeout == 0) {
                 return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, timeoutMillsecondsElasticDefault);
             } else {
-                return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, elasticTimeout);    
+                return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, elasticTimeout);
             }
         } else {
-            return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, timeoutMilliseconds);    
+            return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, timeoutMilliseconds);
         }
     }
-    
+
     private static double getElasticTimeout(int timeoutPercentage, List<Run> builds) {
         return timeoutPercentage * .01D * (timeoutPercentage > 0 ? averageDuration(builds) : 0);
     }
@@ -245,16 +263,16 @@ public class BuildTimeoutWrapper extends BuildWrapper {
     private static double averageDuration(List <Run> builds) {
         int nonFailingBuilds = 0;
         int durationSum= 0;
-        
+
         for (int i = builds.size() - 1; i >= 0 && nonFailingBuilds < NUMBER_OF_BUILDS_TO_AVERAGE; i--) {
             Run run = builds.get(i);
-            if (run.getResult() != null && 
+            if (run.getResult() != null &&
                     run.getResult().isBetterOrEqualTo(Result.UNSTABLE)) {
                 durationSum += run.getDuration();
                 nonFailingBuilds++;
             }
         }
-        
+
         return nonFailingBuilds > 0 ? durationSum / nonFailingBuilds : 0;
     }
 
@@ -264,7 +282,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
         }
         return this;
     }
-    
+
     @Override
     public Descriptor<BuildWrapper> getDescriptor() {
         return DESCRIPTOR;
@@ -289,7 +307,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
         public int[] getPercentages() {
             return new int[] {150,200,250,300,350,400};
         }
-        
+
         @Override
         public BuildWrapper newInstance(StaplerRequest req, JSONObject formData)
                 throws hudson.model.Descriptor.FormException {
@@ -314,6 +332,6 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             }
             return m;
         }
-        
+
     }
 }

--- a/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
@@ -10,7 +10,7 @@
     <f:entry title="${%Timeout as a percentage of recent non-failing builds}" field="timeoutPercentage">
       <f:select />
     </f:entry>
-    <f:entry title="${%Timeout minutes if no successful or unstable builds}" help="/plugin/build-timeout/help-timeoutMinutes.html">
+    <f:entry title="${%Timeout minutes if no successful or unstable builds}" help="/descriptor/hudson.plugins.build_timeout.BuildTimeoutWrapper/help/timeoutMinutes">
       <f:textbox field="timeoutMinutesElasticDefault" default="60" />
     </f:entry>
   </f:radioBlock>

--- a/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
@@ -24,7 +24,7 @@
     <f:checkbox/>
   </f:entry>
 
-  <f:entry title="Execute command on timeout">
+  <f:entry title="${%Execute command on timeout}" help="/plugin/build-timeout/help-timeoutAction.html">
     <f:textbox field="timeoutAction" default="" />
   </f:entry>
 

--- a/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
@@ -1,20 +1,21 @@
-    <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:radioBlock name="build-timeout.timeoutType" value="absolute" title="${%Absolute}" checked="${instance.timeoutType=='absolute'}">
-      <f:entry title="${%Timeout minutes}" field="timeoutMinutes">
-        <f:textbox/>
-      </f:entry>
-    </f:radioBlock>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:radioBlock name="build-timeout.timeoutType" value="elastic" title="${%Elastic}" checked="${instance.timeoutType=='elastic'}">
-      <f:entry title="${%Timeout as a percentage of recent non-failing builds}" field="timeoutPercentage">
-        <f:select />
-      </f:entry>
-      <f:entry title="${%Timeout minutes if no successful or unstable builds}" help="/plugin/build-timeout/help-timeoutMinutes.html">
-        <f:textbox field="timeoutMinutesElasticDefault" default="60" />
-      </f:entry>
-    </f:radioBlock>
+  <f:radioBlock name="build-timeout.timeoutType" value="absolute" title="${%Absolute}" checked="${instance.timeoutType=='absolute'}">
+    <f:entry title="${%Timeout minutes}" field="timeoutMinutes">
+      <f:textbox/>
+    </f:entry>
+  </f:radioBlock>
 
-    <f:radioBlock name="build-timeout.timeoutType" value="likelyStuck" title="${%Likely stuck}" checked="${instance.timeoutType=='likelyStuck'}" help="/plugin/build-timeout/help-likelyStuckConfig.html"/>
+  <f:radioBlock name="build-timeout.timeoutType" value="elastic" title="${%Elastic}" checked="${instance.timeoutType=='elastic'}">
+    <f:entry title="${%Timeout as a percentage of recent non-failing builds}" field="timeoutPercentage">
+      <f:select />
+    </f:entry>
+    <f:entry title="${%Timeout minutes if no successful or unstable builds}" help="/plugin/build-timeout/help-timeoutMinutes.html">
+      <f:textbox field="timeoutMinutesElasticDefault" default="60" />
+    </f:entry>
+  </f:radioBlock>
+
+  <f:radioBlock name="build-timeout.timeoutType" value="likelyStuck" title="${%Likely stuck}" checked="${instance.timeoutType=='likelyStuck'}" help="/plugin/build-timeout/help-likelyStuckConfig.html"/>
 
   <f:entry title="${%Fail the build}" field="failBuild">
     <f:checkbox/>
@@ -22,4 +23,9 @@
   <f:entry title="${%Writing the build description}" field="writingDescription">
     <f:checkbox/>
   </f:entry>
+
+  <f:entry title="Execute command on timeout">
+    <f:textbox field="timeoutAction" default="" />
+  </f:entry>
+
 </j:jelly>

--- a/src/main/webapp/help-timeoutAction.html
+++ b/src/main/webapp/help-timeoutAction.html
@@ -1,0 +1,3 @@
+<div>
+  If not empty, will execute the given Shell script before interrupting the build.<br>
+</div>


### PR DESCRIPTION
Allow execution of a Shell or Batch command just before the effective thread interruption.
