### PR TITLE
Clarified timeoutMinutesElasticDefault's name

### DIFF
--- a/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/BuildTimeoutWrapper/config.jelly
@@ -9,7 +9,7 @@
       <f:entry title="${%Timeout as a percentage of recent non-failing builds}" field="timeoutPercentage">
         <f:select />
       </f:entry>
-      <f:entry title="${%Timeout minutes if no successful or unstable builds}" field="timeoutMinutesElasticDefault" >
+      <f:entry title="${%Timeout to use if there are no previous successful or unstable builds}" field="timeoutMinutesElasticDefault" >
         <f:textbox default="60" />
       </f:entry>
     </f:radioBlock>


### PR DESCRIPTION
Using a different text to describe timeoutMinutesElasticDefault
in the UI so other people don't have to spend several minutes
digging through the source to figure it out. :-)
