### PR TITLE
Fix elastic timout

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -207,7 +207,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
         int nonFailingBuilds = 0;
         int durationSum= 0;
         
-        for (int i = builds.size() - 1; i >= 0 && nonFailingBuilds < NUMBER_OF_BUILDS_TO_AVERAGE; i--) {
+        for (int i = 0; i < builds.size() && nonFailingBuilds < NUMBER_OF_BUILDS_TO_AVERAGE; i++) {
             Run run = builds.get(i);
             if (run.getResult() != null && 
                     run.getResult().isBetterOrEqualTo(Result.UNSTABLE)) {


### PR DESCRIPTION
About elastic timeout, the help says "the three most recent non-failing builds" but I found it actually takes the oldest three.
It aborts very soon if the build was simple at the beginning.

Since the first entry of Job#getBuilds() is the latest build, BuildTimeoutWrapper#getEffectiveTimeout() just needs to take the first three non-failing builds.
So I fixed.

I'm glad if this fix is applied also on jenkinsci.
