### PR TITLE
expose the build timeout with an environment variable

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -2,6 +2,7 @@ package hudson.plugins.build_timeout;
 
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -23,6 +24,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import jenkins.model.Jenkins;
 
@@ -39,6 +41,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
 
     private /* final */ BuildTimeOutStrategy strategy;
+    private final String timeoutEnvVar;
 
     /**
      * Fail the build rather than aborting it
@@ -85,13 +88,15 @@ public class BuildTimeoutWrapper extends BuildWrapper {
     public BuildTimeoutWrapper(BuildTimeOutStrategy strategy, boolean failBuild, boolean writingDescription) {
         this.strategy = strategy;
         this.operationList = createCompatibleOperationList(failBuild, writingDescription);
+        this.timeoutEnvVar = null;
     }
     
 
     @DataBoundConstructor
-    public BuildTimeoutWrapper(BuildTimeOutStrategy strategy, List<BuildTimeOutOperation> operationList) {
+    public BuildTimeoutWrapper(BuildTimeOutStrategy strategy, List<BuildTimeOutOperation> operationList, String timeoutEnvVar) {
         this.strategy = strategy;
         this.operationList = (operationList != null)?operationList:Collections.<BuildTimeOutOperation>emptyList();
+        this.timeoutEnvVar = Util.fixEmptyAndTrim(timeoutEnvVar);
     }
     
     public class EnvironmentImpl extends Environment {
@@ -127,7 +132,14 @@ public class BuildTimeoutWrapper extends BuildWrapper {
                 this.effectiveTimeout = strategy.getTimeOut(build);
                 reschedule();
             }
-            
+
+            @Override
+            public void buildEnvVars(Map<String, String> env) {
+            	if (timeoutEnvVar != null) {
+            		env.put(timeoutEnvVar, String.valueOf(effectiveTimeout));
+           		}
+            }
+
             public void reschedule() {
                 if (task != null) {
                     task.cancel();
@@ -171,7 +183,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             opList = createCompatibleOperationList(failBuild, writingDescription);
         }
         
-        return new BuildTimeoutWrapper(strategy, opList);
+        return new BuildTimeoutWrapper(strategy, opList, timeoutEnvVar);
     }
     
     @Override
@@ -206,6 +218,10 @@ public class BuildTimeoutWrapper extends BuildWrapper {
 
     public BuildTimeOutStrategy getStrategy() {
         return strategy;
+    }
+
+    public String getTimeoutEnvVar() {
+        return timeoutEnvVar;
     }
 
     /**

--- a/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
@@ -406,7 +406,8 @@ public class BuildTimeoutWrapperIntegrationTest extends HudsonTestCase {
         TestBuildTimeOutOperation op3 = new TestBuildTimeOutOperation();
         project.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new QuickBuildTimeOutStrategy(1000),
-                Arrays.<BuildTimeOutOperation>asList(op1, op2, op3)
+                Arrays.<BuildTimeOutOperation>asList(op1, op2, op3),
+                "BUILD_TIMEOUT"
         ));
         project.getBuildersList().add(new SleepBuilder(5000));
         
@@ -439,7 +440,8 @@ public class BuildTimeoutWrapperIntegrationTest extends HudsonTestCase {
         TestBuildTimeOutOperation op3 = new TestBuildTimeOutOperation();
         project.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new QuickBuildTimeOutStrategy(1000),
-                Arrays.<BuildTimeOutOperation>asList(op1, op2, op3)
+                Arrays.<BuildTimeOutOperation>asList(op1, op2, op3),
+                "BUILD_TIMEOUT"
         ));
         project.getBuildersList().add(new SleepBuilder(5000));
         

--- a/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
@@ -64,7 +64,8 @@ public class WriteDescriptionOperationTest {
                 Arrays.<BuildTimeOutOperation>asList(
                         new WriteDescriptionOperation(DESCRIPTION),
                         new AbortOperation()
-                )
+                ),
+                "BUILD_TIMEOUT"
         ));
         p.getBuildersList().add(new SleepBuilder(10000));
         
@@ -84,7 +85,8 @@ public class WriteDescriptionOperationTest {
                 new QuickBuildTimeOutStrategy(5000),
                 Arrays.<BuildTimeOutOperation>asList(
                         new WriteDescriptionOperation(DESCRIPTION)
-                )
+                ),
+                "BUILD_TIMEOUT"
         ));
         p.getBuildersList().add(new SleepBuilder(10000));
         
@@ -107,7 +109,8 @@ public class WriteDescriptionOperationTest {
                         new WriteDescriptionOperation(DESCRIPTION1),
                         new AbortOperation(),
                         new WriteDescriptionOperation(DESCRIPTION2)
-                )
+                ),
+                "BUILD_TIMEOUT"
         ));
         p.getBuildersList().add(new SleepBuilder(10000));
         


### PR DESCRIPTION
It would be nice to have the jenkins job timeout available during the entire build.
Tests, particularly long running tests, can make use of the timeout to evaluate and
do stuff during a test run.  Currently the work around is to set the timeout value in
the jenkins timeout plugin then (using the envinject plugin) inject that value into
job as an environment variable so that it's available globally to the job.  Although
this works it's not a great solution especially if you have tons of projects that needs
to be  updated with that workaround.  Also any workaround would requires two plugins
while this functionality can easily be accomplished with just the build timeout plugin.

This change allows users to set the build timeout to a custom environment variable.
By default the plugin does not set a variable at all, users must explicitly enter
a value into the 'Time-out variable' textbox for the plugin to add the environment
variable to a build.

Also added tests to verify this feature.
