### PR TITLE
[JENKINS-23012] Resolved a performance problem introduced in 1.13 by capturing log outputs.

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -294,6 +294,11 @@ public class BuildTimeoutWrapper extends BuildWrapper {
     @Override
     public OutputStream decorateLogger(@SuppressWarnings("rawtypes") final AbstractBuild build, final OutputStream logger)
             throws IOException, InterruptedException, RunnerAbortedException {
+        if(!getStrategy().wantsCaptureLog()) {
+            // For performance reason, decorates only when
+            // the strategy requires that.
+            return logger;
+        }
         return new OutputStream() {
             @Override
             public void write(int b) throws IOException {


### PR DESCRIPTION
[JENKINS-23012](https://issues.jenkins-ci.org/browse/JENKINS-23012)

Capturing and forwarding log outputs to `BuildTimeOutStrategy` introduced in 2129c5d8fc4a9d9432cf95ce34ce522e646eb3ff causes a performance problem.
Changed to capture only when `BuildTimeOutStrategy#onWrite` is overridden.
