### PR TITLE
[JENKINS-23118] "Enable BuildStep Action" was not saved to the disk.

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
@@ -138,6 +138,10 @@ public class BuildStepOperation extends BuildTimeOutOperation {
     public static class DescriptorImpl extends BuildTimeOutOperationDescriptor {
         private boolean enabled = false;
         
+        public DescriptorImpl() {
+            load();
+        }
+        
         /**
          * Returns whether {@link BuildStepOperation} is enabled.
          * 
@@ -168,6 +172,7 @@ public class BuildStepOperation extends BuildTimeOutOperation {
         public boolean configure(StaplerRequest req, JSONObject json)
                 throws hudson.model.Descriptor.FormException {
             setEnabled(json.containsKey("enabled"));
+            save();
             return true;
         }
         


### PR DESCRIPTION
[JENKINS-23118](https://issues.jenkins-ci.org/browse/JENKINS-23118)

I had to call `save` and `load` explicitly.
