### PR TITLE
[JENKINS-23740] Update BuildTimeoutWrapper.java

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -136,7 +136,7 @@ public class BuildTimeoutWrapper extends BuildWrapper {
                         // defaults to AbortOperation.
                         opList = Arrays.<BuildTimeOutOperation>asList(new AbortOperation());
                     }
-                    for( BuildTimeOutOperation op: getOperationList() ) {
+                    for( BuildTimeOutOperation op: opList ) {
                         try {
                             if (!op.perform(build, listener, effectiveTimeout)) {
                                 operationFailed = true;


### PR DESCRIPTION
Re-use opList so that if null or empty, default to AbortOperation is used.
