### PR TITLE
[JENKINS-26170] improve the peformance of NoActivityTimeOutStrategy

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
@@ -50,8 +50,27 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      * 
      * @param build
      * @param b output character.
+     * 
+     * @deprecated use {@link #onWrite(AbstractBuild, byte[], int)}
+     * 
      */
+    @Deprecated
     public void onWrite(AbstractBuild<?,?> build, int b) {}
+    
+    /**
+     * Called when some output to console.
+     * Override this to capture the activity.
+     * 
+     * @param build
+     * @param b output characters.
+     * @param length length of b to output
+     * 
+     */
+    public void onWrite(AbstractBuild<?,?> build, byte b[], int length) {
+        for(int i = 0; i < length; ++i) {
+            onWrite(build, b[i]);
+        }
+    }
     
     /**
      * Decides whether to call {@link BuildTimeOutStrategy.onWrite}
@@ -64,7 +83,8 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
     public boolean wantsCaptureLog() {
         try {
             Class<?> classOfOnWrite = getClass().getMethod("onWrite", AbstractBuild.class, int.class).getDeclaringClass();
-            return !BuildTimeOutStrategy.class.equals(classOfOnWrite);
+            Class<?> classOfNewOnWrite = getClass().getMethod("onWrite", AbstractBuild.class, byte[].class, int.class).getDeclaringClass();
+            return !BuildTimeOutStrategy.class.equals(classOfOnWrite) || !BuildTimeOutStrategy.class.equals(classOfNewOnWrite);
         } catch(SecurityException e) {
             LOG.log(Level.WARNING, "Unexpected exception in build-timeout-plugin", e);
             return false;

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -3,6 +3,7 @@ package hudson.plugins.build_timeout;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.console.LineTransformationOutputStream;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -314,11 +315,11 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             // the strategy requires that.
             return logger;
         }
-        return new OutputStream() {
+        return new LineTransformationOutputStream() {
             @Override
-            public void write(int b) throws IOException {
-                getStrategy().onWrite(build, b);
-                logger.write(b);
+            protected void eol(byte[] b, int len) throws IOException {
+                getStrategy().onWrite(build, b, len);
+                logger.write(b, 0, len);
             }
             
             @Override

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -323,6 +323,12 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             }
             
             @Override
+            public void flush() throws IOException {
+                super.flush();
+                logger.flush();
+            }
+            
+            @Override
             public void close() throws IOException {
                 logger.close();
                 super.close();

--- a/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
@@ -96,14 +96,11 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
     /**
      * @param build
      * @param b
-     * @see hudson.plugins.build_timeout.BuildTimeOutStrategy#onWrite(int)
+     * @param length
+     * @see hudson.plugins.build_timeout.BuildTimeOutStrategy#onWrite(AbstractBuild, byte[], int)
      */
     @Override
-    public void onWrite(AbstractBuild<?,?> build, int b) {
-        if (b != '\r' && b != '\n') {
-            // process only when it is a line break.
-            return;
-        }
+    public void onWrite(AbstractBuild<?,?> build, byte b[], int length) {
         BuildTimeoutWrapper.EnvironmentImpl env = build.getEnvironments().get(BuildTimeoutWrapper.EnvironmentImpl.class);
         if (env != null) {
             env.rescheduleIfScheduled();


### PR DESCRIPTION
[JENKINS-26170](https://issues.jenkins-ci.org/browse/JENKINS-26170)
`NoActivityTimeOutStrategy` slows builds as it checks logoutputs for each letters.
Using `LineTransformationOutputStream` improves the performance as it buffers outputs and processes outputs by lines.