### PR TITLE
[FIXED JENKINS-30564] 

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -22,7 +22,7 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
 
     private final String numberOfBuilds;
 
-    private boolean failSafeTimeoutDuration;
+    private final boolean failSafeTimeoutDuration;
 
     /**
      * The timeout to use if there are no valid builds in the build
@@ -60,16 +60,12 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
 
     @Deprecated
     public ElasticTimeOutStrategy(int timeoutPercentage, int timeoutMinutesElasticDefault, int numberOfBuilds) {
-        this.timeoutPercentage = Integer.toString(timeoutPercentage);
-        this.timeoutMinutesElasticDefault = Integer.toString(timeoutMinutesElasticDefault);
-        this.numberOfBuilds = Integer.toString(numberOfBuilds);
+        this(Integer.toString(timeoutPercentage), Integer.toString(timeoutMinutesElasticDefault), Integer.toString(numberOfBuilds), false);
     }
 
     @Deprecated
     public ElasticTimeOutStrategy(String timeoutPercentage, String timeoutMinutesElasticDefault, String numberOfBuilds) {
-        this.timeoutPercentage = timeoutPercentage;
-        this.timeoutMinutesElasticDefault = timeoutMinutesElasticDefault;
-        this.numberOfBuilds = numberOfBuilds;
+        this(timeoutPercentage, timeoutMinutesElasticDefault, numberOfBuilds, false);
     }
 
     @DataBoundConstructor
@@ -86,13 +82,13 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         double elasticTimeout = getElasticTimeout(Integer.parseInt(expandAll(build,listener,getTimeoutPercentage())), build, listener);
         if (elasticTimeout == 0) {
             if (isFailSafeTimeoutDuration()) {
-                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60 * 1000, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
+                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60L * 1000L, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
             } else {
                 return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
             }
         } else {
             if (isFailSafeTimeoutDuration()) {
-                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60 * 1000, (long) elasticTimeout);
+                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60L * 1000L, (long) elasticTimeout);
             } else {
                 return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, elasticTimeout);
             }

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -95,7 +95,7 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         }
 
 
-        return nonFailingBuilds > 0 ? ((double)durationSum) / nonFailingBuilds : 0;
+        return nonFailingBuilds >=numberOfBuilds ? ((double)durationSum) / nonFailingBuilds : 0;
     }
 
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -81,14 +81,10 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
             throws InterruptedException, MacroEvaluationException, IOException {
         double elasticTimeout = getElasticTimeout(Integer.parseInt(expandAll(build,listener,getTimeoutPercentage())), build, listener);
         if (elasticTimeout == 0) {
-            if (isFailSafeTimeoutDuration()) {
-                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60L * 1000L, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
-            } else {
-                return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
-            }
+            return Math.max(MINIMUM_TIMEOUT_MILLISECONDS, Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES);
         } else {
             if (isFailSafeTimeoutDuration()) {
-                return Math.max(Integer.parseInt(getTimeoutMinutesElasticDefault()) * 60L * 1000L, (long) elasticTimeout);
+                return Math.max(Integer.parseInt(expandAll(build, listener, getTimeoutMinutesElasticDefault())) * MINUTES, (long) elasticTimeout);
             } else {
                 return (long) Math.max(MINIMUM_TIMEOUT_MILLISECONDS, elasticTimeout);
             }

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -95,7 +95,7 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         }
 
 
-        return nonFailingBuilds >=numberOfBuilds ? ((double)durationSum) / nonFailingBuilds : 0;
+        return (nonFailingBuilds >= numberOfBuilds) ? ((double)durationSum) / nonFailingBuilds : 0;
     }
 
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -95,7 +95,7 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         }
 
 
-        return (nonFailingBuilds >= numberOfBuilds) ? ((double)durationSum) / nonFailingBuilds : 0;
+        return nonFailingBuilds >= numberOfBuilds ? ((double)durationSum) / nonFailingBuilds : 0;
     }
 
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {

--- a/src/main/resources/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy/config.jelly
@@ -12,5 +12,7 @@
            description="${%Timeout to use if there are no previous successful or unstable builds}" >
         <f:textbox default="60" />
     </f:entry>
-
+    <f:entry title="${%Timeout minutes as the shortest timeout}" field="failSafeTimeoutDuration">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
@@ -43,6 +43,22 @@ public class ElasticTimeOutStrategyTest extends TestCase {
         assertEquals("Timeout should be the elastic default.", 90 * MINUTES, strategy.getTimeOut(b,null));
     }
 
+    public void testFailSafeTimeoutDurationWithOneBuild() throws Exception {
+        BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy("200", "60", "3", true);
+
+        Build b = new Build(new Build(20 * MINUTES, SUCCESS));
+
+        assertEquals("Timeout should be the elastic default.", 60 * MINUTES, strategy.getTimeOut(b,null));
+    }
+
+    public void testFailSafeTimeoutDurationWithTwoBuilds() throws Exception {
+        BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy("200", "60", "3", true);
+
+        Build b = new Build(new Build(20 * MINUTES, SUCCESS, new Build(5 * MINUTES, SUCCESS)));
+
+        assertEquals("Timeout should be the elastic default.", 60 * MINUTES, strategy.getTimeOut(b,null));
+    }
+
     private class Build extends FreeStyleBuild {
         Build previous;
         long duration;


### PR DESCRIPTION
`timeoutMinutesElasticDefault` should be used until `numberOfBuilds` is not reached out.

https://issues.jenkins-ci.org/browse/JENKINS-30564

@reviewbybees 