### PR TITLE
[FIXED JENKINS-31627] canceled TimerTasks should be purged.

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeoutWrapper.java
@@ -177,6 +177,8 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             public synchronized void reschedule() {
                 if (task != null) {
                     task.cancel();
+                    // avoid memory leaks for the case where this timer is in the future (JENKINS-31627)
+                    Trigger.timer.purge();
                 }
                 task = new TimeoutTimerTask();
                 Trigger.timer.schedule(task, effectiveTimeout);
@@ -193,6 +195,8 @@ public class BuildTimeoutWrapper extends BuildWrapper {
             public synchronized boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
                 if (task != null) {
                     task.cancel();
+                    // avoid memory leaks for the case where this timer is in the future (JENKINS-31627).
+                    Trigger.timer.purge();
                     task = null;
                 }
                 


### PR DESCRIPTION
The `TimerTask` could be way off into the future as it is user input that
decides when this is run (and or jobs running multiple days the inactivity
could be 1 day).  Without purging the `Timer` the `TimerTask`s stay into the
queue until such time that they are the next task to run - at which time
they are removed.  But with all other triggers in a system (polling every
minute etc) added timers could stay for their maximum duration.

For arguments sake say this is 1 day and you have a build that produces
10000 lines of output every 10 hours and uses the `NoActivity` strategy.
In this case for every call to write you will have a new `TimerTask` created
that should trigger in 24hours time - it is easy to see these 10000
`TimerTask`s are referenced from the `Timer` and as such will not be garbage
collected for a long while.
If you have lots of these styles of jobs - the required heap to run this
becomes massive.

@reviewbybees 
[JENKINS-31627](https://issues.jenkins-ci.org/browse/JENKINS-31627)