### PR TITLE
Clarify 'likely stuck' help text.

### DIFF
--- a/src/main/resources/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy/help.html
+++ b/src/main/resources/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy/help.html
@@ -1,4 +1,3 @@
 <p>
-Use Jenkins' Executor.html#isLikelyStuck() heuristics based approach to detect build is suspiciously taking for a long time
-<br/>
+Abort the build when the job has taken many times longer than previous runs.
 </p>


### PR DESCRIPTION
The previous help text simply referenced the source code, which isn't
helpful for most users.