### PR TITLE
[JENKINS-30564] Failsafe timeout duration for ElasticTimeoutStrategy

### DIFF
--- a/src/main/resources/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy/config.jelly
@@ -12,5 +12,7 @@
            description="${%Timeout to use if there are no previous successful or unstable builds}" >
         <f:textbox default="60" />
     </f:entry>
-
+    <f:entry title="${%Timeout minutes as the shortest timeout}" field="failSafeTimeoutDuration">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
@@ -43,6 +43,22 @@ public class ElasticTimeOutStrategyTest extends TestCase {
         assertEquals("Timeout should be the elastic default.", 90 * MINUTES, strategy.getTimeOut(b,null));
     }
 
+    public void testFailSafeTimeoutDurationWithOneBuild() throws Exception {
+        BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy("200", "60", "3", true);
+
+        Build b = new Build(new Build(20 * MINUTES, SUCCESS));
+
+        assertEquals("Timeout should be the elastic default.", 60 * MINUTES, strategy.getTimeOut(b,null));
+    }
+
+    public void testFailSafeTimeoutDurationWithTwoBuilds() throws Exception {
+        BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy("200", "60", "3", true);
+
+        Build b = new Build(new Build(20 * MINUTES, SUCCESS, new Build(5 * MINUTES, SUCCESS)));
+
+        assertEquals("Timeout should be the elastic default.", 60 * MINUTES, strategy.getTimeOut(b,null));
+    }
+
     private class Build extends FreeStyleBuild {
         Build previous;
         long duration;

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
@@ -59,6 +59,23 @@ public class ElasticTimeOutStrategyTest extends TestCase {
         assertEquals("Timeout should be the elastic default.", 60 * MINUTES, strategy.getTimeOut(b,null));
     }
 
+    public void testFailSafeTimeoutIsNotUsed() throws Exception {
+        BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy("200", "60", "3", true);
+
+        Build b = new Build(
+                new Build(120 * MINUTES, SUCCESS,
+                        new Build(150 * MINUTES, SUCCESS)
+                )
+        );
+
+        // Timeout should be 200 % of average of builds.
+        assertEquals(
+                "Timeout should not be the elastic default.",
+                270 * MINUTES,
+                strategy.getTimeOut(b,null)
+        );
+    }
+
     private class Build extends FreeStyleBuild {
         Build previous;
         long duration;


### PR DESCRIPTION
[JENKINS-30564](https://issues.jenkins-ci.org/browse/JENKINS-30564)

An update of #46.
* Added some tests I commented in https://github.com/jenkinsci/build-timeout-plugin/pull/46#issuecomment-151439114
* Squashed some commits in #46 . I decided to do this as:
    * Commits are not bound to the JIRA issue.
    * There were commits completely overridden by following commits.
    * There were commits with useless comments.

|Commits in #46|New commits|
|:-------------|:----------|
|ea2bc002e9c1895cd68bbed8128d33ea49f8714d, 1555384f5914359a6352d0aaf8cc5ecbedcc8b1b, 650d8a5782dab979b65fded0650ca8b237645e4d, 2152caeb2aa1604917b9efe39c98ed2e78a98b77, a07b3f27bd36b0319c43b019aa5235e4edb4a3a6, cdcc95cc3b408d917f4edc34e0a9f6a093c90940 | 697eafc31c63c015fd5720fee762bba35fb47800|
|b972c308cb3c3170e104c14b2cea1a0d4ad02d82|264a9a73bbf9958d9dab48cae93145185a50ebd0|

My additional commits:
* 2c055aa4b244287f6a80e134654867e70c550f09