### PR TITLE
Prevent temporary directories are left with `ElasticTimeOutStrategyTest`

### DIFF
--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyTest.java
@@ -8,8 +8,13 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.plugins.build_timeout.BuildTimeOutStrategy;
 import junit.framework.TestCase;
+
+import org.apache.commons.io.FileUtils;
 import org.mockito.Mockito;
 
+import com.google.common.io.Files;
+
+import java.io.File;
 import java.io.IOException;
 
 import static hudson.model.Result.SUCCESS;
@@ -19,6 +24,29 @@ import static hudson.plugins.build_timeout.BuildTimeOutStrategy.MINUTES;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ElasticTimeOutStrategyTest extends TestCase {
+
+    private File tempDir;
+
+    private synchronized File getTempDir() {
+        if (tempDir == null) {
+            tempDir = Files.createTempDir();
+        }
+        return tempDir;
+    }
+
+    private synchronized void deleteTempDir() throws IOException {
+        if (tempDir != null) {
+            FileUtils.deleteDirectory(tempDir);
+            tempDir = null;
+        }
+    }
+
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        deleteTempDir();
+    }
 
     public void testPercentageWithOneBuild() throws Exception {
         BuildTimeOutStrategy strategy = new ElasticTimeOutStrategy(200, 60, 3);
@@ -81,6 +109,14 @@ public class ElasticTimeOutStrategyTest extends TestCase {
         @Override
         public void run() {
             //To change body of implemented methods use File | Settings | File Templates.
+        }
+        
+        @Override
+        public File getRootDir() {
+            // this directory is created automatically
+            // when `Run` is instantiated.
+            // Use the temporary directory to be removed.
+            return new File(getTempDir(), getId());
         }
     }
 


### PR DESCRIPTION
Directories like `2016-01-17_13-41-32` are created in the current working directory and not removed when running `ElasticTimeOutStrategyTest`.
It looks caused for mocked `Build` creates its root directory when instantiated.

This change creates a temporary directory in the test case, and create build directories in it.
That temporary directory is removed with `tearDown`.