### PR TITLE
[JENKINS-34846] Force forkCount=1 even when concurrency is set.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,6 @@
     <jenkins-test-harness.version>1.466</jenkins-test-harness.version>
     <jenkins.version>1.466</jenkins.version>
     <java.level>5</java.level>
-    <!-- old jenkins-test-harness doesn't allow concurrent tests -->
-    <concurrency>1</concurrency>
   </properties>
 
   <dependencies>
@@ -72,6 +70,13 @@
     
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- jenkins-test-harness < 1.545 doesn't support concurrent tests. -->
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
https://jenkins.ci.cloudbees.com/job/plugins/job/build-timeout-plugin/137/
failed with following errors:
```
java.lang.Exception: Failed to initialize exploded war
Caused by: java.io.FileNotFoundException: /scratch/jenkins/workspace/plugins/build-timeout-plugin/target/jenkins-for-test/images/48x48/red_anime.gif (No such file or directory)
```

It is caused for concurrent test executions (to be exact, caused for `WarExplorer`).
As jenkins.ci.cloudbees.com overrides `concurrency` unconditionally, I have to set `forkCount` directly.