### PR TITLE
Update AbortAndRestartOperation.java

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperation.java
@@ -116,7 +116,7 @@ public class AbortAndRestartOperation extends BuildTimeOutOperation {
         return new AbortOperation().perform(build, listener, effectiveTimeout);
     }
    
-    @Extension 
+    @Extension(optional = true)
     public static class DescriptorImpl extends BuildTimeOutOperationDescriptor {
         @Override
         public String getDisplayName() {


### PR DESCRIPTION
Naginator really should be optional as per: https://issues.jenkins-ci.org/browse/JENKINS-36696