### PR TITLE
Modernize plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,37 +85,6 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>display-info</id>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>log4j:log4j:*:jar:compile</exclude>
-                                        <exclude>log4j:log4j:*:jar:runtime</exclude>
-                                        <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
-                                        <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                               <enforceBytecodeVersion>
-                                   <excludes combine.children="append">
-                                       <!-- dependencies via jenkins-core-1.466 -->
-                                       <exclude>org.kohsuke:asm3</exclude>
-                                   </excludes>
-                               </enforceBytecodeVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>  
   
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.35</version>
   </parent>
   
   <licenses>
@@ -16,7 +16,7 @@
   
   <artifactId>build-timeout</artifactId>
   <packaging>hpi</packaging>
-  <name>Jenkins build timeout plugin</name>
+  <name>Build Timeout</name>
   <description>Aborts a build if it's taking too long</description>
   <version>1.19-SNAPSHOT</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin</url>
@@ -29,9 +29,8 @@
   </scm>
 
   <properties>
-    <jenkins-test-harness.version>1.466</jenkins-test-harness.version>
-    <jenkins.version>1.466</jenkins.version>
-    <java.level>5</java.level>
+    <jenkins.version>1.625.1</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <dependencies>
@@ -76,13 +75,6 @@
     
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- jenkins-test-harness < 1.545 doesn't support concurrent tests. -->
-                    <forkCount>1</forkCount>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,19 @@
       <version>1.16</version>
       <optional>true</optional>
     </dependency>
+      <dependency>
+          <!-- naginator -->
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>matrix-project</artifactId>
+          <version>1.4</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>junit</artifactId>
+          <version>1.10</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/src/main/java/hudson/plugins/build_timeout/BuildStepWithTimeout.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildStepWithTimeout.java
@@ -1,5 +1,6 @@
 package hudson.plugins.build_timeout;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -73,8 +74,9 @@ public class BuildStepWithTimeout extends Builder implements BuildStep {
     }
 
     @Override
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "No adequate replacement for Trigger.timer found")
     public boolean perform(final Build<?,?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
-        final Timer timer = Trigger.timer;
+        final Timer timer = Trigger.timer; // FIXME TODO replace with Timer
         final long delay = getTimeout(build, listener);
 
         final TimerTask task = new SafeTimerTask() {
@@ -135,7 +137,7 @@ public class BuildStepWithTimeout extends Builder implements BuildStep {
         }
 
         public List<BuildTimeOutStrategyDescriptor> getStrategies() {
-            List<BuildTimeOutStrategyDescriptor> descriptors = Jenkins.getInstance().getDescriptorList(BuildTimeOutStrategy.class);
+            List<BuildTimeOutStrategyDescriptor> descriptors = Jenkins.getActiveInstance().getDescriptorList(BuildTimeOutStrategy.class);
             List<BuildTimeOutStrategyDescriptor> supportedStrategies = new ArrayList<BuildTimeOutStrategyDescriptor>(descriptors.size());
 
             for(BuildTimeOutStrategyDescriptor descriptor : descriptors) {

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperation.java
@@ -31,6 +31,8 @@ import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Describable;
 
+import javax.annotation.Nonnull;
+
 /**
  * Defines an operation performed when timeout occurs.
  * They are called "Timeout Actions", but the class is BuildTimeOutOperation
@@ -47,13 +49,12 @@ public abstract class BuildTimeOutOperation
      * @param effectiveTimeout  timeout (milliseconds)
      * @return false not to run subsequent operations. It also mark the build as failure.
      */
-    public abstract boolean perform(AbstractBuild<?,?> build, BuildListener listener, long effectiveTimeout);
+    public abstract boolean perform(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener, long effectiveTimeout);
     
     /**
-     * @return
      * @see hudson.model.Describable#getDescriptor()
      */
     public BuildTimeOutOperationDescriptor getDescriptor() {
-        return (BuildTimeOutOperationDescriptor)Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (BuildTimeOutOperationDescriptor)Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
     }
 }

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperationDescriptor.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperationDescriptor.java
@@ -41,7 +41,6 @@ public abstract class BuildTimeOutOperationDescriptor extends Descriptor<BuildTi
      * 
      * Override this to restrict project types this action can be applied.
      * 
-     * @param jobType
      * @return
      *      true to allow user to configure this timeout action to given project.
      * @see BuildStepDescriptor#isApplicable(Class)
@@ -51,8 +50,8 @@ public abstract class BuildTimeOutOperationDescriptor extends Descriptor<BuildTi
     }
     
     public static List<BuildTimeOutOperationDescriptor> all(Class<? extends AbstractProject<?,?>> jobType) {
-        List<BuildTimeOutOperationDescriptor> alldescs = Jenkins.getInstance().getDescriptorList(BuildTimeOutOperation.class);
-        List<BuildTimeOutOperationDescriptor> descs = new ArrayList<BuildTimeOutOperationDescriptor>();
+        List<BuildTimeOutOperationDescriptor> alldescs = Jenkins.getActiveInstance().getDescriptorList(BuildTimeOutOperation.class);
+        List<BuildTimeOutOperationDescriptor> descs = new ArrayList<>();
         for (BuildTimeOutOperationDescriptor d: alldescs) {
             if (jobType == null || d.isApplicable(jobType)) {
                 descs.add(d);

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
@@ -12,6 +12,7 @@ import hudson.model.Run;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -28,7 +29,7 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      * @deprecated override {@link #getTimeOut(hudson.model.AbstractBuild, hudson.model.BuildListener)} instead.
      */
     @Deprecated
-    public long getTimeOut(Run run) {
+    public long getTimeOut(@Nonnull Run run) {
         throw new UnsupportedOperationException("Implementation required");
     }
     
@@ -38,7 +39,7 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      * @param listener the build listener
      */
     @SuppressWarnings("deprecation")
-    public long getTimeOut(AbstractBuild<?,?> build, BuildListener listener)
+    public long getTimeOut(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         // call through to the old method.
         return getTimeOut(build);
@@ -85,10 +86,7 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
             Class<?> classOfOnWrite = getClass().getMethod("onWrite", AbstractBuild.class, int.class).getDeclaringClass();
             Class<?> classOfNewOnWrite = getClass().getMethod("onWrite", AbstractBuild.class, byte[].class, int.class).getDeclaringClass();
             return !BuildTimeOutStrategy.class.equals(classOfOnWrite) || !BuildTimeOutStrategy.class.equals(classOfNewOnWrite);
-        } catch(SecurityException e) {
-            LOG.log(Level.WARNING, "Unexpected exception in build-timeout-plugin", e);
-            return false;
-        } catch(NoSuchMethodException e) {
+        } catch(SecurityException|NoSuchMethodException e) {
             LOG.log(Level.WARNING, "Unexpected exception in build-timeout-plugin", e);
             return false;
         }
@@ -100,15 +98,15 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      */
     @SuppressWarnings("unchecked")
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
     }
 
-    protected final String expandAll(AbstractBuild<?, ?> build, BuildListener listener, String string)
+    protected final String expandAll(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, @Nonnull String string)
             throws MacroEvaluationException, IOException, InterruptedException {
         return hasMacros(string) ? TokenMacro.expandAll(build, listener, string) : string;
     }
 
-    protected final static boolean hasMacros(String value) {
+    protected final static boolean hasMacros(@Nonnull String value) {
         return value.contains("${");
     }
    

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutUtility.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutUtility.java
@@ -33,21 +33,12 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-/**
- *
- */
 public class BuildTimeOutUtility {
     /**
      * Construct an object from parameters input by a user.
      * 
      * Not using {@link DataBoundConstructor},
      * but using {@link Descriptor#newInstance(StaplerRequest, JSONObject)}.
-     * 
-     * @param req
-     * @param formData
-     * @param fieldName
-     * @return
-     * @throws hudson.model.Descriptor.FormException
      */
     public static <T> T bindJSONWithDescriptor(StaplerRequest req, JSONObject formData, String fieldName, Class<T> expectedClazz)
             throws hudson.model.Descriptor.FormException {
@@ -65,8 +56,8 @@ public class BuildTimeOutUtility {
         }
         try {
             @SuppressWarnings("unchecked")
-            Class<? extends Describable<?>> clazz = (Class<? extends Describable<?>>)Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(clazzName);
-            Descriptor<?> d = Jenkins.getInstance().getDescriptorOrDie(clazz);
+            Class<? extends Describable<?>> clazz = (Class<? extends Describable<?>>)Jenkins.getActiveInstance().getPluginManager().uberClassLoader.loadClass(clazzName);
+            Descriptor<?> d = Jenkins.getActiveInstance().getDescriptorOrDie(clazz);
             @SuppressWarnings("unchecked")
             T ret = (T)d.newInstance(req, formData);
             return ret;

--- a/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
@@ -1,16 +1,16 @@
 package hudson.plugins.build_timeout.impl;
 
-import static hudson.plugins.build_timeout.BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS;
-
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.plugins.build_timeout.BuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeOutStrategyDescriptor;
+import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -29,7 +29,7 @@ public class AbsoluteTimeOutStrategy extends BuildTimeOutStrategy {
 
     @Deprecated
     public AbsoluteTimeOutStrategy(int timeoutMinutes) {
-        this.timeoutMinutes = Integer.toString(Math.max((int) (MINIMUM_TIMEOUT_MILLISECONDS / MINUTES), timeoutMinutes));
+        this.timeoutMinutes = Integer.toString(Math.max((int) (BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS / MINUTES), timeoutMinutes));
     }
 
     @DataBoundConstructor
@@ -38,9 +38,9 @@ public class AbsoluteTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(AbstractBuild<?,?> build, BuildListener listener)
+    public long getTimeOut(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
-        return MINUTES * Math.max((int) (MINIMUM_TIMEOUT_MILLISECONDS / MINUTES), Integer.parseInt(
+        return MINUTES * Math.max((int) (BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS / MINUTES), Integer.parseInt(
                 expandAll(build, listener, getTimeoutMinutes())));
     }
 

--- a/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
@@ -17,6 +17,8 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.Nonnull;
+
 /**
  * If the build reaches <tt>deadlineTime</tt>, it will be terminated.
  * 
@@ -57,7 +59,7 @@ public class DeadlineTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(AbstractBuild<?, ?> build, BuildListener listener) throws InterruptedException,
+    public long getTimeOut(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener) throws InterruptedException,
             MacroEvaluationException, IOException, IllegalArgumentException {
 
         Calendar now = Calendar.getInstance();
@@ -93,7 +95,7 @@ public class DeadlineTimeOutStrategy extends BuildTimeOutStrategy {
         return deadlineTimestamp.getTimeInMillis() - now.getTimeInMillis();
     }
 
-    private static Date parseDeadline(String deadline) throws IllegalArgumentException {
+    private static Date parseDeadline(@Nonnull String deadline) throws IllegalArgumentException {
 
         if (deadline.matches(DEADLINE_REGEXP)) {
             try {

--- a/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
@@ -14,6 +14,7 @@ import hudson.util.TimeUnit2;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -30,7 +31,7 @@ public class LikelyStuckTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(AbstractBuild<?, ?> run, BuildListener listener)
+    public long getTimeOut(@Nonnull AbstractBuild<?, ?> run, @Nonnull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         Executor executor = run.getExecutor();
         if (executor == null) {

--- a/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
@@ -34,6 +34,7 @@ import hudson.plugins.build_timeout.BuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeOutStrategyDescriptor;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -46,7 +47,6 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
     private final String timeoutSecondsString;
     
     /**
-     * @return
      * @deprecated use {@link NoActivityTimeOutStrategy#getTimeoutSecondsString()} instead.
      */
     @Deprecated
@@ -58,9 +58,6 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
         }
     }
     
-    /**
-     * @return
-     */
     public String getTimeoutSecondsString()
     {
         return timeoutSecondsString;
@@ -74,9 +71,6 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
         return this;
     }
     
-    /**
-     * @param timeoutSecondsString
-     */
     @DataBoundConstructor
     public NoActivityTimeOutStrategy(String timeoutSecondsString) {
         this.timeoutSecondsString = timeoutSecondsString;
@@ -88,17 +82,11 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
     }
     
     @Override
-    public long getTimeOut(AbstractBuild<?, ?> build, BuildListener listener)
+    public long getTimeOut(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         return Long.parseLong(expandAll(build, listener, getTimeoutSecondsString())) * 1000L;
     }
 
-    /**
-     * @param build
-     * @param b
-     * @param length
-     * @see hudson.plugins.build_timeout.BuildTimeOutStrategy#onWrite(AbstractBuild, byte[], int)
-     */
     @Override
     public void onWrite(AbstractBuild<?,?> build, byte b[], int length) {
         BuildTimeoutWrapper.EnvironmentImpl env = build.getEnvironments().get(BuildTimeoutWrapper.EnvironmentImpl.class);

--- a/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
@@ -7,7 +7,6 @@ import hudson.model.Result;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 import hudson.plugins.build_timeout.operations.FailOperation;
 import hudson.tasks.Builder;
-import hudson.util.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,8 +14,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertFalse;
 
 public class BuildStepWithTimeoutTest {
     @Rule
@@ -37,7 +34,7 @@ public class BuildStepWithTimeoutTest {
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
         j.assertBuildStatusSuccess(build);
-        j.assertLogContains("Test", build);
+        j.assertLogContains(FakeBuildStep.FAKE_BUILD_STEP_OUTPUT, build);
     }
 
     @Test
@@ -47,7 +44,7 @@ public class BuildStepWithTimeoutTest {
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
         j.assertBuildStatus(Result.ABORTED, build);
-        assertLogDoesNotContain("Test", build);
+        j.assertLogNotContains(FakeBuildStep.FAKE_BUILD_STEP_OUTPUT, build);
     }
 
 
@@ -58,7 +55,7 @@ public class BuildStepWithTimeoutTest {
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
         j.assertBuildStatus(Result.ABORTED, build);
-        assertLogDoesNotContain("Test", build);
+        j.assertLogNotContains(FakeBuildStep.FAKE_BUILD_STEP_OUTPUT, build);
     }
 
     @Test
@@ -68,7 +65,7 @@ public class BuildStepWithTimeoutTest {
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
         j.assertBuildStatus(Result.FAILURE, build);
-        assertLogDoesNotContain("Test", build);
+        j.assertLogNotContains(FakeBuildStep.FAKE_BUILD_STEP_OUTPUT, build);
     }
 
     private FreeStyleProject createProjectWithBuildStepWithTimeout(long delay, BuildTimeOutOperation operation) throws IOException {
@@ -76,7 +73,7 @@ public class BuildStepWithTimeoutTest {
         final List<BuildTimeOutOperation> operations;
 
         if (operation!=null) {
-            operations = new ArrayList<BuildTimeOutOperation>();
+            operations = new ArrayList<>();
             operations.add(operation);
         }
         else {
@@ -89,9 +86,5 @@ public class BuildStepWithTimeoutTest {
         project.getBuildersList().add(step);
 
         return project;
-    }
-
-    private static void assertLogDoesNotContain(String text, FreeStyleBuild build) throws IOException {
-        assertFalse(IOUtils.toString(build.getLogReader()).contains(text));
     }
 }

--- a/src/test/java/hudson/plugins/build_timeout/FakeBuildStep.java
+++ b/src/test/java/hudson/plugins/build_timeout/FakeBuildStep.java
@@ -12,9 +12,10 @@ import hudson.tasks.Builder;
 import java.io.IOException;
 
 public class FakeBuildStep extends Builder implements BuildStep {
+    static final String FAKE_BUILD_STEP_OUTPUT = "fake-build-step-output";
     private long delay = 0;
     
-    public FakeBuildStep(long delay) {
+    FakeBuildStep(long delay) {
         this.delay = delay;
     }
 
@@ -22,7 +23,7 @@ public class FakeBuildStep extends Builder implements BuildStep {
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         Thread.sleep(delay);
 
-        listener.getLogger().print("Test");
+        listener.getLogger().print(FAKE_BUILD_STEP_OUTPUT);
 
         return true;
     }


### PR DESCRIPTION
* "Jenkins" and "Plugin" get stripped from the name, so remove that and capitalize the rest.
* Update to current parent POM
* Address FindBugs warnings from new parent POM
* Update core and Java dependency to not require a dozen unused implied dependencies: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/ClassicPluginStrategy.java#L413...L427
* Remove empty Javadoc comments that just clog up the tubes.
* Add null-ness annotations

----

Tests still pass, otherwise I'm not confident I didn't mess up some of the internals. Review is needed.