### PR TITLE
Upgrade parent pom and require Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.35</version>
+    <version>3.54</version>
   </parent>
 
   <artifactId>build-timeout</artifactId>
@@ -31,8 +31,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.625.1</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <dependencies>

--- a/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
@@ -30,6 +30,8 @@ import hudson.model.Result;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -68,6 +70,7 @@ public class AbsoluteTimeOutStrategyTest {
     @Test
     public void testConfigurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
                         new AbsoluteTimeOutStrategy("${TIMEOUT}"),

--- a/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
@@ -28,6 +28,8 @@ import hudson.model.Result;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -87,6 +89,7 @@ public class DeadlineTimeOutStrategyTest {
         String deadline = getDeadlineTimeFromNow(timeToDeadlineInSecondsFromNow);
 
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("DEADLINE", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(new DeadlineTimeOutStrategy("${DEADLINE}",
                         TOLERANCE_PERIOD_IN_MINUTES), Arrays

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
@@ -32,6 +32,8 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -95,6 +97,7 @@ public class ElasticTimeOutStrategyJenkinsTest {
     @Test
     public void testFailSafeTimeoutWithVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FailSafeTimeout", null)));
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new ElasticTimeOutStrategy("200", "${FailSafeTimeout}", "3", true),
                 null,

--- a/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
@@ -47,7 +47,9 @@ import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.BuildListener;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -252,6 +254,7 @@ public class NoActivityTimeOutStrategyTest {
     @Test
     public void testConfigurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
                         new NoActivityTimeOutStrategy("${TIMEOUT}"),

--- a/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
@@ -39,6 +39,8 @@ import org.jvnet.hudson.test.SleepBuilder;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.model.Result;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
@@ -116,6 +118,7 @@ public class AbortAndRestartOperationTest {
     @Test
     public void testUsingVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("RESTART", null)));
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                      new QuickBuildTimeOutStrategy(1000),
                      Arrays.<BuildTimeOutOperation>asList(new AbortAndRestartOperation("${RESTART}")),
@@ -140,6 +143,7 @@ public class AbortAndRestartOperationTest {
     @Test
     public void testUsingBadRestart() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("RESTART", null)));
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                      new QuickBuildTimeOutStrategy(1000),
                      Arrays.<BuildTimeOutOperation>asList(new AbortAndRestartOperation("${RESTART}")),

--- a/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
@@ -39,6 +39,8 @@ import hudson.model.Cause;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.model.Result;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
@@ -324,6 +326,7 @@ public class BuildStepOperationTest {
                 Arrays.<BuildTimeOutOperation>asList(op),
                 null
         );
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TESTSTRING", null)));
         p.getBuildWrappersList().add(timeout);
         p.getBuildersList().add(new SleepBuilder(9999));
         
@@ -354,6 +357,7 @@ public class BuildStepOperationTest {
                 Arrays.<BuildTimeOutOperation>asList(op),
                 null
         );
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TESTSTRING", null)));
         p.getBuildWrappersList().add(timeout);
         p.getBuildersList().add(new SleepBuilder(9999));
         


### PR DESCRIPTION
Java 7 is end of life since April 2015. Changing the Java level in the plugin to `8` makes sure that at least Java 8 is used to build the plugin and the plugin can only used with a Jenkins that supports Java 8. Upgrading to the latest parent pom makes sure that the latest features and fixes from the parent pom are used to build the plugin.

Using Jenkins 2.60.3 as it's one of the first Jenkins LTS versions that requires Java 8. That's also the version that many other plugins use as minimum.

Tests are adapted to properly define the used job parameters. This is required due to security changes in Jenkins 1.651.2 (see https://jenkins.io/changelog-stable/#v1.651.2).