### PR TITLE
[JENKINS-62275] Jenkins.MANAGE has access to global config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.35</version>
+    <version>4.1</version>
   </parent>
 
   <artifactId>build-timeout</artifactId>
@@ -31,8 +31,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.625.1</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.222.1</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
   <properties>
     <jenkins.version>2.222.1</jenkins.version>
     <java.level>8</java.level>
+    <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
+    <useBeta>true</useBeta>
   </properties>
 
   <dependencies>

--- a/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
@@ -26,11 +26,16 @@ package hudson.plugins.build_timeout.operations;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -111,8 +116,11 @@ public class BuildStepOperation extends BuildTimeOutOperation {
      * {@link Launcher} that cannot launch anything.
      */
     private static class DummyLauncher extends Launcher {
+
+        private static Logger LOG = Logger.getLogger(BuildStepOperation.DummyLauncher.class.getName());
+
         public DummyLauncher() {
-            super(null, null);
+            super(new LogTaskListener(LOG, Level.INFO), null);
         }
         
         @Override

--- a/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
@@ -35,7 +35,9 @@ import java.util.logging.Logger;
 
 import hudson.model.Node;
 import hudson.model.TaskListener;
+import hudson.security.Permission;
 import hudson.util.LogTaskListener;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -139,7 +141,7 @@ public class BuildStepOperation extends BuildTimeOutOperation {
             throw new UnsupportedOperationException("Launcher does not supported in BuildStep timeout operation");
         }
     }
-    
+
     /**
      * @return launcher specified with launcherOption.
      */
@@ -247,6 +249,12 @@ public class BuildStepOperation extends BuildTimeOutOperation {
             buildsteps.addAll(BuildStepDescriptor.filter(Publisher.all(), project.getClass()));
             
             return buildsteps;
+        }
+
+        @Nonnull
+        @Override
+        public Permission getRequiredGlobalConfigPagePermission() {
+            return Jenkins.MANAGE;
         }
     }
 }

--- a/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
@@ -26,10 +26,12 @@ package hudson.plugins.build_timeout.impl;
 
 import java.util.Arrays;
 
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -68,6 +70,8 @@ public class AbsoluteTimeOutStrategyTest {
     @Test
     public void testConfigurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
                         new AbsoluteTimeOutStrategy("${TIMEOUT}"),

--- a/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
@@ -24,10 +24,12 @@
 
 package hudson.plugins.build_timeout.impl;
 
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -87,6 +89,8 @@ public class DeadlineTimeOutStrategyTest {
         String deadline = getDeadlineTimeFromNow(timeToDeadlineInSecondsFromNow);
 
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("DEADLINE", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(new DeadlineTimeOutStrategy("${DEADLINE}",
                         TOLERANCE_PERIOD_IN_MINUTES), Arrays

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
@@ -32,6 +32,8 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -95,6 +97,8 @@ public class ElasticTimeOutStrategyJenkinsTest {
     @Test
     public void testFailSafeTimeoutWithVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FailSafeTimeout", null)));
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new ElasticTimeOutStrategy("200", "${FailSafeTimeout}", "3", true),
                 null,

--- a/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
@@ -31,6 +31,8 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -252,6 +254,8 @@ public class NoActivityTimeOutStrategyTest {
     @Test
     public void testConfigurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
                         new NoActivityTimeOutStrategy("${TIMEOUT}"),

--- a/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.LinkedList;
 
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.SleepBuilder;
@@ -116,6 +118,8 @@ public class AbortAndRestartOperationTest {
     @Test
     public void testUsingVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("RESTART", null)));
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                      new QuickBuildTimeOutStrategy(1000),
                      Arrays.<BuildTimeOutOperation>asList(new AbortAndRestartOperation("${RESTART}")),

--- a/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
@@ -42,6 +42,8 @@ import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.model.Result;
 import hudson.model.User;
@@ -317,6 +319,8 @@ public class BuildStepOperationTest {
     @Test
     public void testLauncher() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        // needed since Jenkins 2.3
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TESTSTRING", null)));
         
         String TESTSTRING = "***THIS IS OUTPUT IN TIMEOUT***";
         

--- a/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
 
 import hudson.Extension;
 import hudson.Functions;
@@ -37,16 +39,20 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.BuildListener;
+import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 import hudson.model.Result;
+import hudson.model.User;
 import hudson.plugins.build_timeout.BuildTimeOutJenkinsRule;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
 import hudson.plugins.build_timeout.BuildTimeOutOperationDescriptor;
 import hudson.plugins.build_timeout.QuickBuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
@@ -54,12 +60,15 @@ import hudson.tasks.Recorder;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -362,6 +371,31 @@ public class BuildStepOperationTest {
                 new Cause.UserCause(),
                 new ParametersAction(new StringParameterValue("TESTSTRING", TESTSTRING))
         ).get());
+    }
+
+    @Test
+    public void managePermissionShouldAccess() {
+        final String USER = "user";
+        final String MANAGER = "manager";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                // Read access
+                .grant(Jenkins.READ).everywhere().to(USER)
+
+                // Read and Manage
+                .grant(Jenkins.READ).everywhere().to(MANAGER)
+                .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+        );
+
+        try (ACLContext c = ACL.as(User.getById(USER, true))) {
+            Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
+            assertTrue("Global configuration should not be accessible to READ users", descriptors.size() == 0);
+        }
+        try (ACLContext c = ACL.as(User.getById(MANAGER, true))) {
+            Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
+            Optional<Descriptor> found = descriptors.stream().filter(descriptor -> descriptor instanceof BuildStepOperation.DescriptorImpl).findFirst();
+            assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
+        }
     }
     
     /**


### PR DESCRIPTION
[JENKINS-62275](https://issues.jenkins-ci.org/browse/JENKINS-62275)

This is using the new Jenkins.MANAGE permission. It is intended to grant an intermediate access level to global configuration for non admins but more than read users.

Enabling the BuildStep Action falls into this category so users with `Jenkins.MANAGE` should be able to configure it.

(I've also updated the the minimum Jenkins core LTS including the `Jenkins.MANAGE` and updated to a newer parent pom).