### PR TITLE
[INFRA-2463] Update CHANGELOG to point github release pages

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 == Changelog
 
+See the https://github.com/jenkinsci/build-timeout-plugin/releases[Github releases page].
+
+Old changelogs:
+
 === Version 1.19.1 (Feb 15, 2020)
 
 * Improve markups in help texts (https://github.com/jenkinsci/build-timeout-plugin/pull/69[Pull request #69])


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/INFRA-2463
Build-timeout-plugin now uses release drafter and the github release page:
https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
