### PR TITLE
Introduce Global Time Out

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -17,40 +17,67 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static java.util.logging.Level.WARNING;
 
 @Extension
 public class GlobalTimeOutConfiguration extends GlobalConfiguration implements TimeOutProvider {
     private static final Logger log = Logger.getLogger(GlobalTimeOutConfiguration.class.getName());
-    private final transient Jenkins jenkins;
+    private transient Jenkins jenkins;
     private BuildTimeOutStrategy strategy;
     private List<BuildTimeOutOperation> operations;
 
-    /**
-     * Unused - required by sezpoz
-     */
-    @SuppressWarnings("unused")
     public GlobalTimeOutConfiguration() {
-        this(Jenkins.get());
-    }
-
-    @Inject
-    public GlobalTimeOutConfiguration(Jenkins jenkins) {
-        this.jenkins = jenkins;
         load();
     }
 
+    @Inject
+    public void setJenkins(Jenkins jenkins) {
+        this.jenkins = jenkins;
+    }
+
+    /**
+     * Unchecking the 'Enable Global Timeout' box sends a null object for
+     * timeout.global in the json representation of the form submission.
+     *
+     * Binding this to the current class leaves the previous values.
+     * To get around this binding problem, we explicitly null out these fields
+     * before saving.
+     *
+     * @param req the request object
+     * @param json form data as json
+     * @return always true
+     */
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) {
         JSONObject settings = json.getJSONObject("timeout").getJSONObject("global");
-        req.bindJSON(this, settings);
+        if (settings.isNullObject()) {
+            strategy = null;
+            operations = null;
+            log.info("global timeout has been cleared");
+        } else {
+            req.bindJSON(this, settings);
+            log.info(() -> String.format("global timeout updated to %s with operations: %s", strategy, describeOperations()));
+        }
         save();
         return true;
+    }
+
+    @Override
+    public synchronized void load() {
+        super.load();
+        log.info(() -> {
+            if (strategy == null) {
+                return "global timeout not set";
+            }
+            return String.format("global timeout loaded as %s with operations: %s", strategy, describeOperations());
+        });
     }
 
     @Override
@@ -97,5 +124,17 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
 
     public List<BuildTimeOutOperationDescriptor> getAllOperations() {
         return jenkins.getDescriptorList(BuildTimeOutOperation.class);
+    }
+
+    private String describeOperations() {
+        List<BuildTimeOutOperation> nullSafe = operations == null ? Collections.emptyList() : operations;
+        if (nullSafe.isEmpty()) {
+            return "(none)";
+        }
+        return nullSafe.stream()
+                .map(BuildTimeOutOperation::getClass)
+                .map(Class::getSimpleName)
+                .sorted()
+                .collect(Collectors.joining(", "));
     }
 }

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -1,0 +1,101 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.build_timeout.BuildTimeOutOperation;
+import hudson.plugins.build_timeout.BuildTimeOutOperationDescriptor;
+import hudson.plugins.build_timeout.BuildTimeOutStrategy;
+import hudson.plugins.build_timeout.BuildTimeOutStrategyDescriptor;
+import hudson.plugins.build_timeout.operations.AbortOperation;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+
+@Extension
+public class GlobalTimeOutConfiguration extends GlobalConfiguration implements TimeOutProvider {
+    private static final Logger log = Logger.getLogger(GlobalTimeOutConfiguration.class.getName());
+    private final transient Jenkins jenkins;
+    private BuildTimeOutStrategy strategy;
+    private List<BuildTimeOutOperation> operations;
+
+    /**
+     * Unused - required by sezpoz
+     */
+    @SuppressWarnings("unused")
+    public GlobalTimeOutConfiguration() {
+        this(Jenkins.get());
+    }
+
+    @Inject
+    public GlobalTimeOutConfiguration(Jenkins jenkins) {
+        this.jenkins = jenkins;
+        load();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) {
+        JSONObject settings = json.getJSONObject("timeout").getJSONObject("global");
+        req.bindJSON(this, settings);
+        save();
+        return true;
+    }
+
+    @Override
+    public Optional<Duration> timeOutFor(AbstractBuild<?, ?> build, BuildListener listener) {
+        try {
+            if (strategy == null) {
+                return Optional.empty();
+            }
+            return Optional.of(Duration.ofMillis(strategy.getTimeOut(build, listener)));
+        } catch (InterruptedException | MacroEvaluationException | IOException e) {
+            log.log(WARNING, e, () -> String.format("%s failed to determine time out", build.getExternalizableId()));
+            return Optional.empty();
+        }
+    }
+
+    public boolean isEnabled() {
+        return strategy != null;
+    }
+
+    @Override
+    public List<BuildTimeOutOperation> getOperations() {
+        List<BuildTimeOutOperation> nullSafe = operations == null ? new LinkedList<>() : operations;
+        if (nullSafe.isEmpty()) {
+            nullSafe.add(new AbortOperation());
+        }
+        return nullSafe;
+    }
+
+    public void setOperations(List<BuildTimeOutOperation> operations) {
+        this.operations = operations;
+    }
+
+    public BuildTimeOutStrategy getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(BuildTimeOutStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public List<BuildTimeOutStrategyDescriptor> getAllStrategies() {
+        return jenkins.getDescriptorList(BuildTimeOutStrategy.class);
+    }
+
+    public List<BuildTimeOutOperationDescriptor> getAllOperations() {
+        return jenkins.getDescriptorList(BuildTimeOutOperation.class);
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutModule.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutModule.java
@@ -1,0 +1,38 @@
+package hudson.plugins.build_timeout.global;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import hudson.Extension;
+
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+@Extension
+@SuppressWarnings("unused")
+public class GlobalTimeOutModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(TimeOutProvider.class).to(GlobalTimeOutConfiguration.class);
+    }
+
+    @TimeOut
+    @Provides
+    @Singleton
+    ScheduledExecutorService providesScheduler() {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder()
+                .setNameFormat("timeout-%d")
+                .build());
+        executor.setRemoveOnCancelPolicy(true);
+        return Executors.unconfigurableScheduledExecutorService(executor);
+    }
+
+    @Provides
+    @Singleton
+    TimeOutStore providesTimeOutStore() {
+        return new InMemoryTimeOutStore(new HashMap<>());
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
@@ -1,0 +1,55 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Environment;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Extension
+@Singleton
+@SuppressWarnings("unused")
+public class GlobalTimeOutRunListener extends RunListener<Run<?, ?>> {
+    private final ScheduledExecutorService scheduler;
+    private final TimeOutProvider timeOutProvider;
+    private final TimeOutStore store;
+
+    /**
+     * Unused - required by sezpoz
+     */
+    public GlobalTimeOutRunListener() {
+        this(null, null, null);
+    }
+
+    @Inject
+    public GlobalTimeOutRunListener(@TimeOut ScheduledExecutorService scheduler, TimeOutProvider timeOutProvider, TimeOutStore store) {
+        this.scheduler = scheduler;
+        this.timeOutProvider = timeOutProvider;
+        this.store = store;
+    }
+
+    @Override
+    public Environment setUpEnvironment(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+        timeOutProvider.timeOutFor(build, listener)
+                .map(duration -> scheduler.schedule(TimeOutTask.create(timeOutProvider, build, listener, duration),
+                        duration.toMillis(),
+                        TimeUnit.MILLISECONDS))
+                .ifPresent(future -> store.scheduled(build.getExternalizableId(), future));
+        return super.setUpEnvironment(build, launcher, listener);
+    }
+
+    @Override
+    public void onCompleted(Run<?, ?> run, @Nonnull TaskListener listener) {
+        store.cancel(run.getExternalizableId());
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStore.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStore.java
@@ -1,0 +1,39 @@
+package hudson.plugins.build_timeout.global;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.logging.Logger;
+
+public class InMemoryTimeOutStore implements TimeOutStore {
+    private static final Logger log = Logger.getLogger(InMemoryTimeOutStore.class.getName());
+    private final Map<String, ScheduledFuture<?>> map;
+
+    public InMemoryTimeOutStore(Map<String, ScheduledFuture<?>> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void scheduled(String key, ScheduledFuture<?> timeOut) {
+        ScheduledFuture<?> previous = map.putIfAbsent(key, timeOut);
+        boolean added = previous == null;
+        if (added) {
+            log.fine(() -> String.format("%s time out stored", key));
+        } else {
+            log.fine(() -> String.format("%s time out already present - skipping", key));
+        }
+    }
+
+    @Override
+    public void cancel(String key) {
+        ScheduledFuture<?> future = map.remove(key);
+        if (future == null) {
+            log.fine(() -> String.format("%s time out not found - skipping", key));
+            return;
+        }
+        boolean cancelled = future.cancel(false);
+        if (cancelled) {
+            log.fine(() -> String.format("%s time out cancellation succeeded", key));
+        }
+        log.fine(() -> String.format("tracking %d global time out(s)", map.size()));
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/Lifecycle.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/Lifecycle.java
@@ -1,0 +1,35 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.Extension;
+import hudson.init.Terminator;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+
+@Extension
+@SuppressWarnings("unused")
+public class Lifecycle {
+    private static final Logger log = Logger.getLogger(Lifecycle.class.getName());
+    private final ScheduledExecutorService scheduler;
+
+    /**
+     * Unused - required by sezpoz
+     */
+    public Lifecycle() {
+        this(null);
+    }
+
+    @Inject
+    public Lifecycle(@TimeOut ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Terminator
+    public void shutdown() {
+        log.fine(() -> "Shutting down Global TimeOut ScheduledExecutorService...");
+        List<Runnable> timeOuts = scheduler.shutdownNow();
+        log.info(() -> String.format("Shutdown complete - Global TimeOut ScheduledExecutorService had %d tasks pending", timeOuts.size()));
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOut.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOut.java
@@ -1,0 +1,14 @@
+package hudson.plugins.build_timeout.global;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier @Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface TimeOut {
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOutProvider.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOutProvider.java
@@ -1,0 +1,14 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.build_timeout.BuildTimeOutOperation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+public interface TimeOutProvider {
+    Optional<Duration> timeOutFor(AbstractBuild<? ,?> build, BuildListener listener);
+    List<BuildTimeOutOperation> getOperations();
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOutStore.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOutStore.java
@@ -1,0 +1,8 @@
+package hudson.plugins.build_timeout.global;
+
+import java.util.concurrent.ScheduledFuture;
+
+public interface TimeOutStore {
+    void scheduled(String key, ScheduledFuture<?> timeOut);
+    void cancel(String key);
+}

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOutTask.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOutTask.java
@@ -1,0 +1,61 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.build_timeout.BuildTimeOutOperation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TimeOutTask implements Runnable {
+    private static final Logger log = Logger.getLogger(TimeOutTask.class.getName());
+    private final TimeOutProvider timeOutProvider;
+    private final AbstractBuild<?, ?> build;
+    private final BuildListener listener;
+    private final Duration duration;
+
+    private TimeOutTask(TimeOutProvider timeOutProvider, AbstractBuild<?, ?> build, BuildListener listener, Duration duration) {
+        this.timeOutProvider = timeOutProvider;
+        this.build = build;
+        this.listener = listener;
+        this.duration = duration;
+    }
+
+    @Override
+    public void run() {
+        List<BuildTimeOutOperation> operations = timeOutProvider.getOperations();
+        for (BuildTimeOutOperation operation : operations) {
+            try {
+                boolean succeeded = operation.perform(build, listener, duration.toMillis());
+                if (!succeeded) {
+                    log.info(() -> String.format(
+                            "%s failed to perform global time out %s after %d minutes - no further operations will be run",
+                            build.getExternalizableId(),
+                            operation.getClass().getSimpleName(),
+                            duration.toMinutes()
+                    ));
+                    return;
+                }
+                listener.getLogger().println("[build-timeout] Global time out activated");
+                log.fine(() -> String.format(
+                        "%s successfully performed global time out %s after %d minutes",
+                        build.getExternalizableId(),
+                        operation.getClass().getSimpleName(),
+                        duration.toMinutes()));
+            } catch (RuntimeException e) {
+                log.log(Level.WARNING, e, () -> String.format(
+                        "%s failed to perform global time out %s after %d minutes - no further operations will be run",
+                        build.getExternalizableId(),
+                        operation.getClass().getSimpleName(),
+                        duration.toMinutes()));
+                return;
+            }
+        }
+    }
+
+    public static TimeOutTask create(TimeOutProvider timeOutProvider, AbstractBuild<?, ?> build, BuildListener listener, Duration duration) {
+        return new TimeOutTask(timeOutProvider, build, listener, duration);
+    }
+}

--- a/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.StringJoiner;
 
 /**
  * If the build took longer than {@code timeoutMinutes} amount of minutes, it will be terminated.
@@ -47,6 +48,13 @@ public class AbsoluteTimeOutStrategy extends BuildTimeOutStrategy {
     @Override
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {
         return DESCRIPTOR;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", AbsoluteTimeOutStrategy.class.getSimpleName() + "[", "]")
+                .add("timeoutMinutes='" + timeoutMinutes + "'")
+                .toString();
     }
 
     @Extension(ordinal=100) // This is displayed at the top as the default

--- a/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
@@ -12,6 +12,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.StringJoiner;
 
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -109,6 +110,14 @@ public class DeadlineTimeOutStrategy extends BuildTimeOutStrategy {
         }
 
         throw new IllegalArgumentException(Messages.DeadlineTimeOutStrategy_InvalidDeadlineFormat(deadline));
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", DeadlineTimeOutStrategy.class.getSimpleName() + "[", "]")
+                .add("deadlineTime='" + deadlineTime + "'")
+                .add("deadlineToleranceInMinutes=" + deadlineToleranceInMinutes)
+                .toString();
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -14,6 +14,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.StringJoiner;
 
 public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
 
@@ -111,6 +112,16 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         }
 
         return nonFailingBuilds > 0 ? ((double)durationSum) / nonFailingBuilds : 0;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ElasticTimeOutStrategy.class.getSimpleName() + "[", "]")
+                .add("timeoutPercentage='" + timeoutPercentage + "'")
+                .add("numberOfBuilds='" + numberOfBuilds + "'")
+                .add("failSafeTimeoutDuration=" + failSafeTimeoutDuration)
+                .add("timeoutMinutesElasticDefault='" + timeoutMinutesElasticDefault + "'")
+                .toString();
     }
 
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {

--- a/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -49,6 +50,13 @@ public class LikelyStuckTimeOutStrategy extends BuildTimeOutStrategy {
         }
     }
 
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", LikelyStuckTimeOutStrategy.class.getSimpleName() + "[", "]")
+                .add("preferred='10 x estimated duration'")
+                .add("fallback='24 hours'")
+                .toString();
+    }
 
     public Descriptor<BuildTimeOutStrategy> getDescriptor() {
         return DESCRIPTOR;

--- a/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
@@ -36,6 +36,7 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.StringJoiner;
 
 /**
  * Timeout when specified time passed since the last output.
@@ -94,7 +95,15 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
             env.rescheduleIfScheduled();
         }
     }
-    
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", NoActivityTimeOutStrategy.class.getSimpleName() + "[", "]")
+                .add("(deprecated)timeout=" + timeout)
+                .add("timeoutSecondsString='" + timeoutSecondsString + "'")
+                .toString();
+    }
+
     @Extension
     public static class DescriptorImpl extends BuildTimeOutStrategyDescriptor {
         @Override

--- a/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+
+<f:section name="timeout" title="Global Build Time Out">
+    <st:adjunct includes="hudson.plugins.build_timeout.nestedHelp"/>
+    <f:optionalBlock name="global" title="Enable Global Time Out" checked="${instance.enabled}">
+        <f:dropdownDescriptorSelector title="${%Time-out strategy}" field="strategy" descriptors="${instance.allStrategies}" />
+        <f:entry title="${%Time-out actions}" field="operations">
+              <f:hetero-list name="operations" hasHeader="true"
+                descriptors="${instance.allOperations}" items="${instance.operations}"
+                addCaption="${%Add action}" />
+            </f:entry>
+    </f:optionalBlock>
+
+</f:section>
+</j:jelly>

--- a/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
@@ -4,22 +4,27 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class GlobalTimeOutRunListenerTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     @Mock
     private TimeOutProvider timeOutProvider;
     @Mock
@@ -35,7 +40,6 @@ public class GlobalTimeOutRunListenerTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         listener = new GlobalTimeOutRunListener(
                 Executors.newSingleThreadScheduledExecutor(),
                 timeOutProvider,
@@ -59,6 +63,6 @@ public class GlobalTimeOutRunListenerTest {
 
         listener.setUpEnvironment(build, launcher, buildListener);
 
-        verifyZeroInteractions(timeOutStore);
+        verifyNoInteractions(timeOutStore);
     }
 }

--- a/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
@@ -1,0 +1,64 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class GlobalTimeOutRunListenerTest {
+    @Mock
+    private TimeOutProvider timeOutProvider;
+    @Mock
+    private TimeOutStore timeOutStore;
+    private GlobalTimeOutRunListener listener;
+
+    @Mock
+    private AbstractBuild<?, ?> build;
+    @Mock
+    private Launcher launcher;
+    @Mock
+    private BuildListener buildListener;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        listener = new GlobalTimeOutRunListener(
+                Executors.newSingleThreadScheduledExecutor(),
+                timeOutProvider,
+                timeOutStore
+        );
+    }
+
+    @Test
+    public void shouldStoreIfPresent() throws IOException, InterruptedException {
+        given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.of(Duration.ofMillis(1)));
+        given(build.getExternalizableId()).willReturn("a#1");
+
+        listener.setUpEnvironment(build, launcher, buildListener);
+
+        verify(timeOutStore).scheduled(eq("a#1"), any());
+    }
+
+    @Test
+    public void shouldNotStoreIfAbsent() throws IOException, InterruptedException {
+        given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.empty());
+
+        listener.setUpEnvironment(build, launcher, buildListener);
+
+        verifyZeroInteractions(timeOutStore);
+    }
+}

--- a/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
@@ -1,0 +1,70 @@
+package hudson.plugins.build_timeout.global;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class InMemoryTimeOutStoreTest {
+    private final Map<String, ScheduledFuture<?>> map = new HashMap<>();
+    private final TimeOutStore store = new InMemoryTimeOutStore(map);
+
+    @Test
+    public void shouldKeep() {
+        store.scheduled("a", mock(ScheduledFuture.class));
+
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey("a"));
+    }
+
+    @Test
+    public void shouldNoOpIfKeyAlreadyExists() {
+        store.scheduled("a", mock(ScheduledFuture.class));
+        assertEquals(1, map.size());
+
+        store.scheduled("a", mock(ScheduledFuture.class));
+
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void shouldRemoveKeyFromMap() {
+        store.scheduled("a", mock(ScheduledFuture.class));
+        store.scheduled("b", mock(ScheduledFuture.class));
+
+        store.cancel("b");
+
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey("a"));
+    }
+
+    @Test
+    public void shouldCancel() {
+        ScheduledFuture<?> a = mock(ScheduledFuture.class);
+        ScheduledFuture<?> b = mock(ScheduledFuture.class);
+        store.scheduled("a", a);
+        store.scheduled("b", b);
+
+        store.cancel("b");
+
+        verifyZeroInteractions(a);
+        verify(b).cancel(false);
+    }
+
+    @Test
+    public void shouldNoOpIfAbsent() {
+        store.scheduled("a", mock(ScheduledFuture.class));
+        assertEquals(1, map.size());
+
+        store.cancel("c");
+
+        assertEquals(1, map.size());
+    }
+}

--- a/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class InMemoryTimeOutStoreTest {
     private final Map<String, ScheduledFuture<?>> map = new HashMap<>();
@@ -54,7 +54,7 @@ public class InMemoryTimeOutStoreTest {
 
         store.cancel("b");
 
-        verifyZeroInteractions(a);
+        verifyNoInteractions(a);
         verify(b).cancel(false);
     }
 

--- a/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
@@ -5,10 +5,13 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
@@ -18,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 public class TimeOutTaskTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     @Mock
     private TimeOutProvider timeOutProvider;
     @Mock
@@ -28,7 +33,6 @@ public class TimeOutTaskTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         task = TimeOutTask.create(timeOutProvider, build, listener, Duration.ofMillis(1));
     }
 

--- a/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
@@ -1,0 +1,104 @@
+package hudson.plugins.build_timeout.global;
+
+import com.google.common.collect.Lists;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.build_timeout.BuildTimeOutOperation;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+public class TimeOutTaskTest {
+    @Mock
+    private TimeOutProvider timeOutProvider;
+    @Mock
+    private AbstractBuild<?, ?> build;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private BuildListener listener;
+    private TimeOutTask task;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        task = TimeOutTask.create(timeOutProvider, build, listener, Duration.ofMillis(1));
+    }
+
+    @Test
+    public void shouldCallAllOperations() {
+        TestOp one = new TestOp();
+        TestOp two = new TestOp();
+        given(timeOutProvider.getOperations()).willReturn(Lists.newArrayList(one, two));
+
+        task.run();
+
+        assertTrue(one.performed);
+        assertTrue(two.performed);
+    }
+
+    @Test
+    public void shouldStopAtFirstFailure() {
+        TestOp one = new TestOp();
+        FailsOp two = new FailsOp();
+        TestOp three = new TestOp();
+        given(timeOutProvider.getOperations()).willReturn(Lists.newArrayList(one, two, three));
+
+        task.run();
+
+        assertTrue(one.performed);
+        assertTrue(two.performed);
+        assertFalse(three.performed);
+    }
+
+    @Test
+    public void shouldStopAtFirstException() {
+        TestOp one = new TestOp();
+        ThrowsOp two = new ThrowsOp();
+        TestOp three = new TestOp();
+        given(timeOutProvider.getOperations()).willReturn(Lists.newArrayList(one, two, three));
+
+        task.run();
+
+        assertTrue(one.performed);
+        assertTrue(two.performed);
+        assertFalse(three.performed);
+    }
+
+    private static class TestOp extends BuildTimeOutOperation {
+        boolean performed = false;
+
+        @Override
+        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+            performed = true;
+            return true;
+        }
+    }
+
+    private static class FailsOp extends BuildTimeOutOperation {
+        boolean performed = false;
+
+        @Override
+        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+            performed = true;
+            return false;
+        }
+    }
+
+    private static class ThrowsOp extends BuildTimeOutOperation {
+        boolean performed = false;
+
+        @Override
+        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+            performed = true;
+            throw new RuntimeException("bad");
+        }
+    }
+}


### PR DESCRIPTION
This change introduces a global build time out that re-uses the existing strategies and operations. The current functionality requires users to opt-in and update the configuration of each build.

### Goal
I'd like to use a global timeout to ensure builds don't run longer than the set time. Occasionally builds hang, and in large deployments it's easy for this to go unnoticed. A hanging build that goes unnoticed occupies an executor indefinitely, reducing the capacity of the system and potentially allowing the queue for a particular job to build up.

### Implementation
On each build:
  1. Find a configured global time out
  2. Schedule the configured time out operations on a dedicated ScheduledExecutorService with one thread
  3. Once complete, cancel the task

Implemented with a `hudson.model.listeners.RunListener` so it can be applied to every build. The existing implementation uses a `hudson.tasks.BuildWrapper`, which requires a checkbox on each build.

### Screenshots
The configuration screen looks like this:
![system-configuration](https://user-images.githubusercontent.com/230004/90346208-0bae6880-dfdc-11ea-91f5-80b782828eb8.png)

When a build fails due to a global timeout, it is noted in the build's log:
![build-log](https://user-images.githubusercontent.com/230004/90346224-241e8300-dfdc-11ea-9964-4fd61b8b67b6.png)

Extensive logging is available on the FINE level:
![logs](https://user-images.githubusercontent.com/230004/90346240-44e6d880-dfdc-11ea-9025-cdf66bf76188.png)
