### PR TITLE
Update dependencies to migrate from Java 8 to 11

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,6 @@
 == Changelog
 
-See the https://github.com/jenkinsci/build-timeout-plugin/releases[Github releases page].
+See the https://github.com/jenkinsci/build-timeout-plugin/releases[GitHub releases page].
 
 Old changelogs:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
-// for https://ci.jenkins.io/
-buildPlugin(configurations: [
-                [platform: 'linux', jdk: '8'],
+#!/usr/bin/env groovy
+
+/* For https://ci.jenkins.io/ */
+/* The `buildPlugin` step has been provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(useContainerAgent: true, configurations: [
                 [platform: 'linux', jdk: '11'],
                 [platform: 'windows', jdk: '11'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.1</version>
+    <version>4.33</version>
   </parent>
 
   <artifactId>build-timeout</artifactId>
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <name>Build Timeout</name>
-  <description>Aborts a build if it's taking too long</description>
+  <description>Terminates a build if it is taking too long</description>
   <url>https://github.com/jenkinsci/build-timeout-plugin</url>
   <licenses>
     <license>
@@ -31,41 +31,101 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.222.1</jenkins.version>
-    <java.level>8</java.level>
+    <!-- Dependency org.jenkins-ci.plugins:mailer:jar:412.v7deeda_155287 requires Jenkins 2.331 or higher. -->
+    <jenkins.version>2.334</jenkins.version>
+    <java.level>11</java.level>
     <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
     <useBeta>true</useBeta>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.9.0</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+          <release>11</release>
+          <!-- Start for debugging -->
+          <!-- Please feel free to uncomment during debugging -->
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <!-- End for debugging -->
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>3.22</version>
+        <configuration>
+          <minimumJavaVersion>11</minimumJavaVersion>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.21</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java17</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>token-macro</artifactId>
-      <version>1.5.1</version>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.23</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>naginator</artifactId>
-      <version>1.16</version>
+      <version>1.18.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <!-- naginator -->
+      <!-- Required by Naginator as a dependency  -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.4</version>
+      <version>1.20</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.10</version>
+      <version>1.53</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>3.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
+      <version>4.3.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -74,6 +134,36 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.78</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>412.v7deeda_155287</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>267.vcdaea6462991</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>625.v2e7cf5fc4211</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>308.v852b473a2b8c</version>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -81,11 +171,19 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
+    <repository>
+      <id>repo.jenkins-ci.org/incrementals</id>
+      <url>https://repo.jenkins-ci.org/incrementals/</url>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org/incrementals</id>
+      <url>https://repo.jenkins-ci.org/incrementals/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## Description
Fixes #86, plus patches the existing issues and vulnerabilities to make the upgrade work via the following:

1. Bumped Jenkins version to 2.333 for security reasons. (Needed a version that is >= 2.331 for a plugin. Otherwise there would be some vulnerability issues remained.)
2. Added minimum Java version to be 11, instead of the previous version 8. 
3. Added dependencies to make the transition from Java 8 to 11 to switch the JVM. 
4. Added plugin configurations for the upgrade while enabling the tests to be passed.
5. Added `https://repo.jenkins-ci.org/incrementals` for `incrementals` downloads. (Also to patch some vulnerability issues.)

Additionally, both the commands `mvn verfiy` then `mvn hpi:run` have been run sequentially and vulnerabilities checked to make sure everything runs smoothly to the best of one's knowledge. No new tests have been added due to the "upgrading" nature of this PR, as only the `pom.xml` file, the `Jenkinsfile`, and the `CHANGELOG.adoc` file at the root have been changed. 

Rationale for the upgrade can be found in Issue #86, with links to source documentations there. 

## Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes (N/A)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (N/A)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
