### PR TITLE
Refresh plugin build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -126,19 +126,11 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
-    <repository>
-      <id>repo.jenkins-ci.org/incrementals</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org/incrementals</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,16 +5,17 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.33</version>
+    <version>4.37</version>
+    <relativePath />
   </parent>
 
   <artifactId>build-timeout</artifactId>
-  <version>1.21-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Build Timeout</name>
   <description>Terminates a build if it is taking too long</description>
-  <url>https://github.com/jenkinsci/build-timeout-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>
       <name>The MIT License (MIT)</name>
@@ -24,16 +25,18 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/build-timeout-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/build-timeout-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/build-timeout-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
-    <!-- Dependency org.jenkins-ci.plugins:mailer:jar:412.v7deeda_155287 requires Jenkins 2.331 or higher. -->
-    <jenkins.version>2.334</jenkins.version>
-    <java.level>11</java.level>
+    <revision>1.21</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.332.1</jenkins.version>
+    <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
     <useBeta>true</useBeta>
   </properties>
@@ -43,11 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.9.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
-          <release>11</release>
           <!-- Start for debugging -->
           <!-- Please feel free to uncomment during debugging -->
           <showDeprecation>true</showDeprecation>
@@ -56,47 +55,22 @@
           <!-- End for debugging -->
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <version>3.22</version>
-        <configuration>
-          <minimumJavaVersion>11</minimumJavaVersion>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.21</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>symbol-annotation</artifactId>
-      <version>1.23</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>naginator</artifactId>
@@ -107,13 +81,11 @@
       <!-- Required by Naginator as a dependency  -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.20</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.53</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -125,44 +97,27 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.3.1</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.78</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>412.v7deeda_155287</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>267.vcdaea6462991</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>625.v2e7cf5fc4211</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>308.v852b473a2b8c</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
- * If the build took longer than <tt>timeoutMinutes</tt> amount of minutes, it will be terminated.
+ * If the build took longer than {@code timeoutMinutes} amount of minutes, it will be terminated.
  */
 public class AbsoluteTimeOutStrategy extends BuildTimeOutStrategy {
 

--- a/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
@@ -20,7 +20,7 @@ import org.kohsuke.stapler.QueryParameter;
 import javax.annotation.Nonnull;
 
 /**
- * If the build reaches <tt>deadlineTime</tt>, it will be terminated.
+ * If the build reaches {@code deadlineTime}, it will be terminated.
  * 
  * @author Fernando Miguélez Palomo (fernando.miguelez@gmail.com)
  */


### PR DESCRIPTION
#87 was not correct. As long as the Jenkins project has not dropped support for Java 8, plugins need to be built with `<release>8</release>`, as defined in the plugin parent POM.