### PR TITLE
EOL JSR 305

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutOperation.java
@@ -31,7 +31,7 @@ import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Describable;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Defines an operation performed when timeout occurs.
@@ -49,7 +49,7 @@ public abstract class BuildTimeOutOperation
      * @param effectiveTimeout  timeout (milliseconds)
      * @return false not to run subsequent operations. It also mark the build as failure.
      */
-    public abstract boolean perform(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener, long effectiveTimeout);
+    public abstract boolean perform(@NonNull AbstractBuild<?,?> build, @NonNull BuildListener listener, long effectiveTimeout);
     
     /**
      * @see hudson.model.Describable#getDescriptor()

--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
@@ -12,7 +12,7 @@ import hudson.model.Run;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -29,7 +29,7 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      * @deprecated override {@link #getTimeOut(hudson.model.AbstractBuild, hudson.model.BuildListener)} instead.
      */
     @Deprecated
-    public long getTimeOut(@Nonnull Run run) {
+    public long getTimeOut(@NonNull Run run) {
         throw new UnsupportedOperationException("Implementation required");
     }
     
@@ -39,7 +39,7 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
      * @param listener the build listener
      */
     @SuppressWarnings("deprecation")
-    public long getTimeOut(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener)
+    public long getTimeOut(@NonNull AbstractBuild<?,?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         // call through to the old method.
         return getTimeOut(build);
@@ -101,12 +101,12 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
         return Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
     }
 
-    protected final String expandAll(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, @Nonnull String string)
+    protected final String expandAll(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener, @NonNull String string)
             throws MacroEvaluationException, IOException, InterruptedException {
         return hasMacros(string) ? TokenMacro.expandAll(build, listener, string) : string;
     }
 
-    protected final static boolean hasMacros(@Nonnull String value) {
+    protected final static boolean hasMacros(@NonNull String value) {
         return value.contains("${");
     }
    

--- a/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategy.java
@@ -10,7 +10,7 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -38,7 +38,7 @@ public class AbsoluteTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(@Nonnull AbstractBuild<?,?> build, @Nonnull BuildListener listener)
+    public long getTimeOut(@NonNull AbstractBuild<?,?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         return MINUTES * Math.max((int) (BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS / MINUTES), Integer.parseInt(
                 expandAll(build, listener, getTimeoutMinutes())));

--- a/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategy.java
@@ -17,7 +17,7 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * If the build reaches <tt>deadlineTime</tt>, it will be terminated.
@@ -59,7 +59,7 @@ public class DeadlineTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener) throws InterruptedException,
+    public long getTimeOut(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener) throws InterruptedException,
             MacroEvaluationException, IOException, IllegalArgumentException {
 
         Calendar now = Calendar.getInstance();
@@ -95,7 +95,7 @@ public class DeadlineTimeOutStrategy extends BuildTimeOutStrategy {
         return deadlineTimestamp.getTimeInMillis() - now.getTimeInMillis();
     }
 
-    private static Date parseDeadline(@Nonnull String deadline) throws IllegalArgumentException {
+    private static Date parseDeadline(@NonNull String deadline) throws IllegalArgumentException {
 
         if (deadline.matches(DEADLINE_REGEXP)) {
             try {

--- a/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategy.java
@@ -12,7 +12,7 @@ import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
@@ -76,7 +76,7 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener)
+    public long getTimeOut(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         double elasticTimeout = getElasticTimeout(Integer.parseInt(expandAll(build,listener,getTimeoutPercentage())), build, listener);
         if (elasticTimeout == 0) {
@@ -90,12 +90,12 @@ public class ElasticTimeOutStrategy extends BuildTimeOutStrategy {
         }
     }
 
-    private double getElasticTimeout(int timeoutPercentage, @Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener)
+    private double getElasticTimeout(int timeoutPercentage, @NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         return timeoutPercentage * .01D * (timeoutPercentage > 0 ? averageDuration(build,listener) : 0);
     }
 
-    private double averageDuration(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener)
+    private double averageDuration(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         int nonFailingBuilds = 0;
         int durationSum = 0;

--- a/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/LikelyStuckTimeOutStrategy.java
@@ -11,7 +11,7 @@ import hudson.plugins.build_timeout.BuildTimeOutStrategyDescriptor;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -29,7 +29,7 @@ public class LikelyStuckTimeOutStrategy extends BuildTimeOutStrategy {
     }
 
     @Override
-    public long getTimeOut(@Nonnull AbstractBuild<?, ?> run, @Nonnull BuildListener listener)
+    public long getTimeOut(@NonNull AbstractBuild<?, ?> run, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         Executor executor = run.getExecutor();
         if (executor == null) {

--- a/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java
@@ -34,7 +34,7 @@ import hudson.plugins.build_timeout.BuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeOutStrategyDescriptor;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -82,7 +82,7 @@ public class NoActivityTimeOutStrategy extends BuildTimeOutStrategy {
     }
     
     @Override
-    public long getTimeOut(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener)
+    public long getTimeOut(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         return Long.parseLong(expandAll(build, listener, getTimeoutSecondsString())) * 1000L;
     }

--- a/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
+++ b/src/main/java/hudson/plugins/build_timeout/operations/BuildStepOperation.java
@@ -63,7 +63,7 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Timeout Action to perform any specified {@link BuildStep}, which includes {@link Builder} and {@link Publisher}.
@@ -145,7 +145,7 @@ public class BuildStepOperation extends BuildTimeOutOperation {
     /**
      * @return launcher specified with launcherOption.
      */
-    protected Launcher createLauncher(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener) {
+    protected Launcher createLauncher(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener) {
         if(!isCreateLauncher()) {
             return new DummyLauncher();
         }
@@ -170,7 +170,7 @@ public class BuildStepOperation extends BuildTimeOutOperation {
     }
     
     @Override
-    public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+    public boolean perform(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener, long effectiveTimeout) {
         boolean result;
         try {
             result = getBuildstep().perform(build, createLauncher(build, listener), listener);
@@ -251,7 +251,7 @@ public class BuildStepOperation extends BuildTimeOutOperation {
             return buildsteps;
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public Permission getRequiredGlobalConfigPagePermission() {
             return Jenkins.MANAGE;


### PR DESCRIPTION
Jenkins core has deprecated the use of JSR 305 annotations in favor of SpotBugs annotations for several core releases, and I have been slowly migrating the entire plugin ecosystem to the new set of annotations. This PR matches dozens of other PRs that have already been merged and released in other plugins to migrate to the new annotations.