### PR TITLE
the incremental repository should not be specified.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,23 +131,11 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
-    <repository>
-      <!-- Required for using incremental versions of dependencies -->
-      <!-- Please do not remove -->
-      <id>repo.jenkins-ci.org.incrementals</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <!-- Required for using incremental versions of dependencies -->
-      <!-- Please do not remove -->
-      <id>repo.jenkins-ci.org.incrementals</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
The comment for incrementals consuming was incorrect and neither the
repository nor the pluginRepository should be specified like this.

the profile (consume-incrementals) that enables both is set in the plugin-pom and this is
enabled in this plugin using .mvn/maven.config


see https://github.com/jenkinsci/build-timeout-plugin/pull/92/files#r884975577

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
