### PR TITLE
Let individual jobs overwrite the global timeout

### DIFF
--- a/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
@@ -10,7 +10,9 @@
               <f:hetero-list name="operations" hasHeader="true"
                 descriptors="${instance.allOperations}" items="${instance.operations}"
                 addCaption="${%Add action}" />
-            </f:entry>
+        </f:entry>
+        <f:optionalBlock field="overwriteable" name="overwriteable" inline="true" 
+                title="Are individual jobs allowed to override this global timeout?" checked="${instance.overwriteable}"/>
     </f:optionalBlock>
 
 </f:section>

--- a/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration/config.jelly
@@ -12,7 +12,7 @@
                 addCaption="${%Add action}" />
         </f:entry>
         <f:optionalBlock field="overwriteable" name="overwriteable" inline="true" 
-                title="Are individual jobs allowed to override this global timeout?" checked="${instance.overwriteable}"/>
+                title="Are individual jobs allowed to overwrite this global timeout?" checked="${instance.overwriteable}"/>
     </f:optionalBlock>
 
 </f:section>


### PR DESCRIPTION
I added a checkbook to the global config to let individual jobs overwrite the global timeout, if this is enabled and the job uses a specific `BuildStepWithTimeout`. If the job does that, I assume it wants to overwrite the global timeout, otherwise it doesn't make sense in my eyes, otherwise I would just omit the step as described in this #94.

![Bildschirmfoto 2022-08-20 um 15 56 37](https://user-images.githubusercontent.com/26878018/185749568-c31b2f0a-11bc-4c34-83da-e8638d4725de.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

