### PR TITLE
Bug fix: Fix global timeout configuration logging bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.361.x</artifactId>
-        <version>1382.v7d694476f340</version>
+        <version>1706.vc166d5f429f8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <revision>1.25</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.332.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
     <useBeta>true</useBeta>
@@ -61,7 +61,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <version>1382.v7d694476f340</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>naginator</artifactId>
-      <version>1.18.1</version>
+      <version>1.18.2</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -61,10 +61,10 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) {
         JSONObject settings = json.getJSONObject("timeout").getJSONObject("global");
+        overwriteable = false;
         if (settings.isNullObject()) {
             strategy = null;
             operations = null;
-            overwriteable = false;
             log.info("global timeout has been cleared");
         } else {
             req.bindJSON(this, settings);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #100. 

## Description
Set the `overwriteable` variable default value to `false` regardless whether the settings is a null object or not. This should prevent excessive logging from being generated. 

## Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes (N/A)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue: Ran `mvn verify` to make sure the build is not broken. 

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
