### PR TITLE
Fix global timeout logging for Abstract Project issue

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
+++ b/src/main/java/hudson/plugins/build_timeout/BuildTimeOutStrategy.java
@@ -3,12 +3,8 @@ package hudson.plugins.build_timeout;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.model.BuildListener;
+import hudson.model.*;
 import jenkins.model.Jenkins;
-import hudson.model.AbstractBuild;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.model.Run;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
@@ -42,6 +38,11 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
     public long getTimeOut(@NonNull AbstractBuild<?,?> build, @NonNull BuildListener listener)
             throws InterruptedException, MacroEvaluationException, IOException {
         // call through to the old method.
+        return getTimeOut(build);
+    }
+
+    public long getTimeOut(@NonNull Run build, @NonNull BuildListener listener)
+        throws InterruptedException, MacroEvaluationException, IOException {
         return getTimeOut(build);
     }
 
@@ -109,5 +110,4 @@ public abstract class BuildTimeOutStrategy implements Describable<BuildTimeOutSt
     protected final static boolean hasMacros(@NonNull String value) {
         return value.contains("${");
     }
-   
 }

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -2,6 +2,7 @@ package hudson.plugins.build_timeout.global;
 
 import hudson.Extension;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Project;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
@@ -86,7 +87,7 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
     }
 
     @Override
-    public Optional<Duration> timeOutFor(AbstractBuild<?, ?> build, BuildListener listener) {
+    public Optional<Duration> timeOutFor(AbstractBuild<?,?> build, BuildListener listener) {
         try {
             List<Builder> builders = ((Project<?, ?>) build.getProject()).getBuilders();
             Optional<Builder> timeoutBuildStep = builders.stream().filter(builder -> builder instanceof BuildStepWithTimeout).findAny();
@@ -111,6 +112,11 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
             log.log(WARNING, e, () -> String.format("%s failed to determine time out", build.getExternalizableId()));
             return Optional.empty();
         }
+    }
+
+    @Override
+    public Optional<Duration> timeOutFor(AbstractProject<?,?> build, BuildListener listener) {
+        return Optional.empty();
     }
 
     public boolean isEnabled() {

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
@@ -2,11 +2,7 @@ package hudson.plugins.build_timeout.global;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Environment;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
 import hudson.model.listeners.RunListener;
 
 import javax.annotation.Nonnull;
@@ -46,6 +42,9 @@ public class GlobalTimeOutRunListener extends RunListener<Run<?, ?>> {
                         TimeUnit.MILLISECONDS))
                 .ifPresent(future -> store.scheduled(build.getExternalizableId(), future));
         return super.setUpEnvironment(build, launcher, listener);
+    }
+
+    public void setUpEnvironment(AbstractProject build, Launcher launcher, BuildListener listener) {
     }
 
     @Override

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOutProvider.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOutProvider.java
@@ -1,6 +1,7 @@
 package hudson.plugins.build_timeout.global;
 
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
 
@@ -9,6 +10,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TimeOutProvider {
-    Optional<Duration> timeOutFor(AbstractBuild<? ,?> build, BuildListener listener);
+    Optional<Duration> timeOutFor(AbstractBuild<?,?> build, BuildListener listener);
+
+    Optional<Duration> timeOutFor(AbstractProject<?,?> build, BuildListener listener);
+
     List<BuildTimeOutOperation> getOperations();
 }

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOutTask.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOutTask.java
@@ -55,7 +55,7 @@ public class TimeOutTask implements Runnable {
         }
     }
 
-    public static TimeOutTask create(TimeOutProvider timeOutProvider, AbstractBuild<?, ?> build, BuildListener listener, Duration duration) {
+    public static TimeOutTask create(TimeOutProvider timeOutProvider, AbstractBuild<?,?> build, BuildListener listener, Duration duration) {
         return new TimeOutTask(timeOutProvider, build, listener, duration);
     }
 }

--- a/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerForAbstractProjectsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerForAbstractProjectsTest.java
@@ -1,0 +1,37 @@
+package hudson.plugins.build_timeout.global;
+
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class GlobalTimeOutRunListenerForAbstractProjectsTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
+    @Mock
+    private TimeOutProvider timeOutProvider;
+    @Mock
+    private TimeOutStore timeOutStore;
+
+    @Mock
+    private AbstractProject<?, ?> build;
+
+    @Mock
+    private BuildListener buildListener;
+
+    @Test
+    public void shouldNotStoreForMatrixProjects() {
+        given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.empty());
+
+        verifyNoInteractions(timeOutStore);
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #100 

## Description
Add overloading of the `timeOutFor` method for `hudson.model.AbstractProject` in `src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java` and add corresponding overloading of `setUpEnvironment` method in `src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java` to make sure this does nothing when we have a Matrix job or any job that is inherited from the `AbstractProject` class. Previous failed attempt to solve this include #104. This will be a more thorough treatment of the issue compared to that superficial one.  

## Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
