### PR TITLE
Third attempt at fixing logging problem for Matrix jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <revision>1.27</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.375.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
     <useBeta>true</useBeta>
@@ -61,8 +61,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1706.vc166d5f429f8</version>
+        <artifactId>bom-2.375.x</artifactId>
+        <version>1742.vb_70478c1b_25f</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -87,6 +87,11 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
     }
 
     @Override
+    public Optional<Duration> timeOutFor(AbstractProject<?,?> build, BuildListener listener) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Duration> timeOutFor(AbstractBuild<?,?> build, BuildListener listener) {
         try {
             List<Builder> builders = ((Project<?, ?>) build.getProject()).getBuilders();
@@ -96,27 +101,21 @@ public class GlobalTimeOutConfiguration extends GlobalConfiguration implements T
                 return Optional.empty();
             }
             return Optional.of(Duration.ofMillis(strategy.getTimeOut(build, listener)));
-
-        } catch (ClassCastException e) {
-            log.log(WARNING, e, () -> String.format("%s cannot allow individual jobs to overwrite timeout due to ClassCastException", build.getExternalizableId()));
-            if (strategy == null) {
-                return Optional.empty();
-            }
-            try {
-                return Optional.of(Duration.ofMillis(strategy.getTimeOut(build, listener)));
-            } catch (InterruptedException | MacroEvaluationException | IOException ex) {
-                log.log(WARNING, ex, () -> String.format("%s failed to determine time out", build.getExternalizableId()));
-                return Optional.empty();
-            }
+//        } catch (ClassCastException e) {
+//            log.log(WARNING, e, () -> String.format("%s cannot allow individual jobs to overwrite timeout due to ClassCastException", build.getExternalizableId()));
+//            if (strategy == null) {
+//                return Optional.empty();
+//            }
+//            try {
+//                return Optional.of(Duration.ofMillis(strategy.getTimeOut(build, listener)));
+//            } catch (InterruptedException | MacroEvaluationException | IOException ex) {
+//                log.log(WARNING, ex, () -> String.format("%s failed to determine time out", build.getExternalizableId()));
+//                return Optional.empty();
+//            }
         } catch (InterruptedException | MacroEvaluationException | IOException e) {
             log.log(WARNING, e, () -> String.format("%s failed to determine time out", build.getExternalizableId()));
             return Optional.empty();
         }
-    }
-
-    @Override
-    public Optional<Duration> timeOutFor(AbstractProject<?,?> build, BuildListener listener) {
-        return Optional.empty();
     }
 
     public boolean isEnabled() {

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +46,13 @@ public class GlobalTimeOutRunListener extends RunListener<Run<?, ?>> {
         return super.setUpEnvironment(build, launcher, listener);
     }
 
-    public void setUpEnvironment(AbstractProject build, Launcher launcher, BuildListener listener) {
+    public Environment setUpEnvironment(AbstractProject<?,?> build, Launcher launcher, BuildListener listener) {
+        return new Environment() {
+            @Override
+            public void buildEnvVars(Map<String, String> env) {
+                super.buildEnvVars(env);
+            }
+        };
     }
 
     @Override

--- a/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerForAbstractProjectsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerForAbstractProjectsTest.java
@@ -1,7 +1,9 @@
 package hudson.plugins.build_timeout.global;
 
+import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -10,6 +12,7 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
 import java.util.Optional;
+import java.util.concurrent.Executors;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -21,16 +24,30 @@ public class GlobalTimeOutRunListenerForAbstractProjectsTest {
     private TimeOutProvider timeOutProvider;
     @Mock
     private TimeOutStore timeOutStore;
+    private GlobalTimeOutRunListener listener;
 
     @Mock
     private AbstractProject<?, ?> build;
+    @Mock
+    private Launcher launcher;
 
     @Mock
     private BuildListener buildListener;
 
+    @Before
+    public void setup() {
+        listener = new GlobalTimeOutRunListener(
+                Executors.newSingleThreadScheduledExecutor(),
+                timeOutProvider,
+                timeOutStore
+        );
+    }
+
     @Test
     public void shouldNotStoreForMatrixProjects() {
         given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.empty());
+
+        listener.setUpEnvironment(build, launcher, buildListener);
 
         verifyNoInteractions(timeOutStore);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Description
Third attempt to attempt to resolve #100. Got rid of the `ClassCastException` now that the `timeOutFor()` for the global timeout is overloaded for both the `AbstractProject` and `AbstractBuild` classes. 

## Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
