### PR TITLE
EOL JSR 305

### DIFF
--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
@@ -5,7 +5,7 @@ import hudson.Launcher;
 import hudson.model.*;
 import hudson.model.listeners.RunListener;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class GlobalTimeOutRunListener extends RunListener<Run<?, ?>> {
     }
 
     @Override
-    public void onCompleted(Run<?, ?> run, @Nonnull TaskListener listener) {
+    public void onCompleted(Run<?, ?> run, @NonNull TaskListener listener) {
         store.cancel(run.getExternalizableId());
     }
 }

--- a/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 
 import static org.junit.Assert.assertFalse;
@@ -80,7 +80,7 @@ public class TimeOutTaskTest {
         boolean performed = false;
 
         @Override
-        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+        public boolean perform(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener, long effectiveTimeout) {
             performed = true;
             return true;
         }
@@ -90,7 +90,7 @@ public class TimeOutTaskTest {
         boolean performed = false;
 
         @Override
-        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+        public boolean perform(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener, long effectiveTimeout) {
             performed = true;
             return false;
         }
@@ -100,7 +100,7 @@ public class TimeOutTaskTest {
         boolean performed = false;
 
         @Override
-        public boolean perform(@Nonnull AbstractBuild<?, ?> build, @Nonnull BuildListener listener, long effectiveTimeout) {
+        public boolean perform(@NonNull AbstractBuild<?, ?> build, @NonNull BuildListener listener, long effectiveTimeout) {
             performed = true;
             throw new RuntimeException("bad");
         }


### PR DESCRIPTION
Several years ago, Jenkins core switched from the abandoned JSR 305 annotations to SpotBugs annotations, but this plugin never caught up. This PR adapts this plugin to the common convention used in Jenkins core and the vast majority of other Jenkins plugins.