### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/plugins/build_timeout/nestedHelp.js
+++ b/src/main/resources/hudson/plugins/build_timeout/nestedHelp.js
@@ -23,23 +23,23 @@
  */
 Behaviour.register({".build-timeout-nested-help": function(e) {
   // ensure Behavior is applied only once.
-  $(e).removeClassName("build-timeout-nested-help");
-  new Ajax.Request(e.getAttribute("helpURL"), {
-    method : 'get',
-    onSuccess : function(x) {
-      e.innerHTML = x.responseText;
-      var myselfName = e.getAttribute("myselfName");
-      var pluginName = x.getResponseHeader("X-Plugin-Short-Name");
-      if (myselfName != pluginName) {
-        var from = x.getResponseHeader("X-Plugin-From");
-        if (from) {
-          e.innerHTML += "<div class='from-plugin'>"+from+"</div>";
+  e.classList.remove("build-timeout-nested-help");
+  fetch(e.getAttribute("helpURL")).then((rsp) => {
+    if (rsp.ok) {
+      rsp.text().then((responseText) => {
+        e.innerHTML = responseText;
+        var myselfName = e.getAttribute("myselfName");
+        var pluginName = rsp.headers.get("X-Plugin-Short-Name");
+        if (myselfName != pluginName) {
+          var from = rsp.headers.get("X-Plugin-From");
+          if (from) {
+            e.innerHTML += "<div class='from-plugin'>"+from+"</div>";
+          }
         }
-      }
-      layoutUpdateCallback.call();
-    },
-    onFailure : function(x) {
-      e.innerHTML = "<b>ERROR</b>: Failed to load help file: " + x.statusText;
+        layoutUpdateCallback.call();
+      });
+    } else {
+      e.innerHTML = "<b>ERROR</b>: Failed to load help file: " + rsp.statusText;
     }
   });
 }});
@@ -48,6 +48,6 @@ Behaviour.register({".build-timeout-nested-help": function(e) {
  * Allows run Behavior when help is loaded.
  */
 layoutUpdateCallback.add(function() {
-  $$(".build-timeout-nested-help").each(function(e){Behaviour.applySubtree(e, true)});
+  document.querySelectorAll(".build-timeout-nested-help").forEach(function(e){Behaviour.applySubtree(e, true)});
 });
 


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), clicked on the help button for Time-out strategy, and verified that the changed lines were executed correctly in my browser's JavaScript debugger.