### PR TITLE
Use JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
@@ -7,9 +7,10 @@ import hudson.model.Result;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 import hudson.plugins.build_timeout.operations.FailOperation;
 import hudson.tasks.Builder;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
@@ -24,14 +25,14 @@ public class BuildStepWithTimeoutTest {
     private final static long TINY_DELAY = 100L;
     private final static long HUGE_DELAY = 5000L;
 
-    @Before
+    @BeforeEach
     public void before() {
         // this allows timeout shorter than 3 minutes.
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 100;
     }
 
     @Test
-    public void timeoutWasNotTriggered() throws Exception {
+    void timeoutWasNotTriggered() throws Exception {
         final FreeStyleProject project = createProjectWithBuildStepWithTimeout(TINY_DELAY, null);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
@@ -41,7 +42,7 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    public void timeoutWasTriggeredWithoutAction() throws Exception {
+    void timeoutWasTriggeredWithoutAction() throws Exception {
         final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, null);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
@@ -51,7 +52,7 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    public void timeoutWasTriggeredWithAbortOperation() throws Exception {
+    void timeoutWasTriggeredWithAbortOperation() throws Exception {
         final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new AbortOperation());
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
@@ -61,7 +62,7 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    public void timeoutWasTriggeredWithFailOperation() throws Exception {
+    void timeoutWasTriggeredWithFailOperation() throws Exception {
         final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new FailOperation());
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();

--- a/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildStepWithTimeoutTest.java
@@ -7,20 +7,18 @@ import hudson.model.Result;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 import hudson.plugins.build_timeout.operations.FailOperation;
 import hudson.tasks.Builder;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BuildStepWithTimeoutTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class BuildStepWithTimeoutTest {
 
     private final static long TINY_DELAY = 100L;
     private final static long HUGE_DELAY = 5000L;
@@ -32,8 +30,8 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    void timeoutWasNotTriggered() throws Exception {
-        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(TINY_DELAY, null);
+    void timeoutWasNotTriggered(JenkinsRule j) throws Exception {
+        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(TINY_DELAY, null, j);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
@@ -42,8 +40,8 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    void timeoutWasTriggeredWithoutAction() throws Exception {
-        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, null);
+    void timeoutWasTriggeredWithoutAction(JenkinsRule j) throws Exception {
+        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, null, j);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
@@ -52,8 +50,8 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    void timeoutWasTriggeredWithAbortOperation() throws Exception {
-        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new AbortOperation());
+    void timeoutWasTriggeredWithAbortOperation(JenkinsRule j) throws Exception {
+        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new AbortOperation(), j);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
@@ -62,8 +60,8 @@ public class BuildStepWithTimeoutTest {
     }
 
     @Test
-    void timeoutWasTriggeredWithFailOperation() throws Exception {
-        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new FailOperation());
+    void timeoutWasTriggeredWithFailOperation(JenkinsRule j) throws Exception {
+        final FreeStyleProject project = createProjectWithBuildStepWithTimeout(HUGE_DELAY, new FailOperation(), j);
 
         final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
@@ -71,7 +69,7 @@ public class BuildStepWithTimeoutTest {
         j.assertLogNotContains(FakeBuildStep.FAKE_BUILD_STEP_OUTPUT, build);
     }
 
-    private FreeStyleProject createProjectWithBuildStepWithTimeout(long delay, BuildTimeOutOperation operation) throws IOException {
+    private FreeStyleProject createProjectWithBuildStepWithTimeout(long delay, BuildTimeOutOperation operation, JenkinsRule j) throws IOException {
         final FreeStyleProject project = j.createFreeStyleProject();
         final List<BuildTimeOutOperation> operations;
 

--- a/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
@@ -24,8 +24,7 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
-
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -39,7 +38,11 @@ import org.htmlunit.html.HtmlPage;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class BuildTimeoutWrapperIntegrationTest {
 
@@ -59,11 +62,11 @@ public class BuildTimeoutWrapperIntegrationTest {
 		return captureEnvBuilder.getEnvVars();
 	}
 
-    /*
-     * Test to verify setting a timeout environment variable to a valid string
-     */
-    @Test
-    void buildTimeoutEnvValid() throws Exception {
+	/*
+	 * Test to verify setting a timeout environment variable to a valid string
+	 */
+	@Test
+	public void buildTimeoutEnvValid() throws Exception {
 		EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 	  	project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -80,11 +83,11 @@ public class BuildTimeoutWrapperIntegrationTest {
 		assertEquals("12345", envVars.get("BUILD_TIMEOUT"));
 	}
 
-    /*
-     * Test to verify setting timeout environment variable to null (this is the default)
-     */
-    @Test
-    void buildTimeoutEnvNull() throws Exception {
+	/*
+	 * Test to verify setting timeout environment variable to null (this is the default)
+	 */
+	@Test
+	public void buildTimeoutEnvNull() throws Exception {
 	    EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -100,11 +103,11 @@ public class BuildTimeoutWrapperIntegrationTest {
   		assertEquals(expectedEnvVars.size(), envVars.size());
 	}
 
-    /*
-     * Test to verify setting timeout environment variable to empty string.
-     */
-    @Test
-    void buildTimeoutEnvEmpty() throws Exception {
+	/*
+	 * Test to verify setting timeout environment variable to empty string.
+	 */
+	@Test
+	public void buildTimeoutEnvEmpty() throws Exception {
 		EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -119,10 +122,10 @@ public class BuildTimeoutWrapperIntegrationTest {
 
   		assertEquals(expectedEnvVars.size(), envVars.size());
 	}
-
-    @Issue("JENKINS-9203")
-    @Test
-    void issue9203() throws Exception {
+	
+	@Issue("JENKINS-9203")
+	@Test
+	public void issue9203() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(new QuickBuildTimeOutStrategy(), true, false));
@@ -192,7 +195,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void abort() throws Exception {
+    public void abort() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         // No description
         {
@@ -263,7 +266,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void fail() throws Exception {
+    public void fail() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         // No description
         {
@@ -495,7 +498,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void multipleOperations() throws Exception {
+    public void multipleOperations() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         FreeStyleProject project = j.createFreeStyleProject();
         TestBuildTimeOutOperation op1 = new TestBuildTimeOutOperation();
@@ -529,7 +532,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void failingOperations() throws Exception {
+    public void failingOperations() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         FreeStyleProject project = j.createFreeStyleProject();
         TestBuildTimeOutOperation op1 = new TestBuildTimeOutOperation();
@@ -563,7 +566,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void configurationNoOperation() throws Exception {
+    public void configurationNoOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -606,7 +609,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void configurationSingleOperation() throws Exception {
+    public void configurationSingleOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -662,7 +665,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    void configurationMultipleOperation() throws Exception {
+    public void configurationMultipleOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -720,10 +723,10 @@ public class BuildTimeoutWrapperIntegrationTest {
                 p.getBuildWrappersList().get(BuildTimeoutWrapper.class).getTimeoutEnvVar()
         );
     }
-
+    
     @LocalData
     @Test
-    void migrationFrom_1_13() throws Exception {
+    public void migrationFrom_1_13() throws Exception {
         Thread.sleep(60000);
         FreeStyleProject p = j.jenkins.getItemByFullName("NoActivityTimeOutStrategy", FreeStyleProject.class);
         assertNotNull(p);

--- a/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/BuildTimeoutWrapperIntegrationTest.java
@@ -24,7 +24,8 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -38,11 +39,7 @@ import org.htmlunit.html.HtmlPage;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BuildTimeoutWrapperIntegrationTest {
 
@@ -62,11 +59,11 @@ public class BuildTimeoutWrapperIntegrationTest {
 		return captureEnvBuilder.getEnvVars();
 	}
 
-	/*
-	 * Test to verify setting a timeout environment variable to a valid string
-	 */
-	@Test
-	public void buildTimeoutEnvValid() throws Exception {
+    /*
+     * Test to verify setting a timeout environment variable to a valid string
+     */
+    @Test
+    void buildTimeoutEnvValid() throws Exception {
 		EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 	  	project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -83,11 +80,11 @@ public class BuildTimeoutWrapperIntegrationTest {
 		assertEquals("12345", envVars.get("BUILD_TIMEOUT"));
 	}
 
-	/*
-	 * Test to verify setting timeout environment variable to null (this is the default)
-	 */
-	@Test
-	public void buildTimeoutEnvNull() throws Exception {
+    /*
+     * Test to verify setting timeout environment variable to null (this is the default)
+     */
+    @Test
+    void buildTimeoutEnvNull() throws Exception {
 	    EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -103,11 +100,11 @@ public class BuildTimeoutWrapperIntegrationTest {
   		assertEquals(expectedEnvVars.size(), envVars.size());
 	}
 
-	/*
-	 * Test to verify setting timeout environment variable to empty string.
-	 */
-	@Test
-	public void buildTimeoutEnvEmpty() throws Exception {
+    /*
+     * Test to verify setting timeout environment variable to empty string.
+     */
+    @Test
+    void buildTimeoutEnvEmpty() throws Exception {
 		EnvVars expectedEnvVars = getEnvVars();
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -122,10 +119,10 @@ public class BuildTimeoutWrapperIntegrationTest {
 
   		assertEquals(expectedEnvVars.size(), envVars.size());
 	}
-	
-	@Issue("JENKINS-9203")
-	@Test
-	public void issue9203() throws Exception {
+
+    @Issue("JENKINS-9203")
+    @Test
+    void issue9203() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
 		FreeStyleProject project = j.createFreeStyleProject();
 		project.getBuildWrappersList().add(new BuildTimeoutWrapper(new QuickBuildTimeOutStrategy(), true, false));
@@ -195,7 +192,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void abort() throws Exception {
+    void abort() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         // No description
         {
@@ -266,7 +263,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void fail() throws Exception {
+    void fail() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         // No description
         {
@@ -498,7 +495,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void multipleOperations() throws Exception {
+    void multipleOperations() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         FreeStyleProject project = j.createFreeStyleProject();
         TestBuildTimeOutOperation op1 = new TestBuildTimeOutOperation();
@@ -532,7 +529,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void failingOperations() throws Exception {
+    void failingOperations() throws Exception {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
         FreeStyleProject project = j.createFreeStyleProject();
         TestBuildTimeOutOperation op1 = new TestBuildTimeOutOperation();
@@ -566,7 +563,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void configurationNoOperation() throws Exception {
+    void configurationNoOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -609,7 +606,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void configurationSingleOperation() throws Exception {
+    void configurationSingleOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -665,7 +662,7 @@ public class BuildTimeoutWrapperIntegrationTest {
     }
 
     @Test
-    public void configurationMultipleOperation() throws Exception {
+    void configurationMultipleOperation() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new AbsoluteTimeOutStrategy(3),
@@ -723,10 +720,10 @@ public class BuildTimeoutWrapperIntegrationTest {
                 p.getBuildWrappersList().get(BuildTimeoutWrapper.class).getTimeoutEnvVar()
         );
     }
-    
+
     @LocalData
     @Test
-    public void migrationFrom_1_13() throws Exception {
+    void migrationFrom_1_13() throws Exception {
         Thread.sleep(60000);
         FreeStyleProject p = j.jenkins.getItemByFullName("NoActivityTimeOutStrategy", FreeStyleProject.class);
         assertNotNull(p);

--- a/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListenerTest.java
@@ -3,13 +3,12 @@ package hudson.plugins.build_timeout.global;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -22,9 +21,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+@ExtendWith(MockitoExtension.class)
 public class GlobalTimeOutRunListenerTest {
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     @Mock
     private TimeOutProvider timeOutProvider;
     @Mock
@@ -38,7 +36,7 @@ public class GlobalTimeOutRunListenerTest {
     @Mock
     private BuildListener buildListener;
 
-    @Before
+    @BeforeEach
     public void setup() {
         listener = new GlobalTimeOutRunListener(
                 Executors.newSingleThreadScheduledExecutor(),
@@ -48,7 +46,7 @@ public class GlobalTimeOutRunListenerTest {
     }
 
     @Test
-    public void shouldStoreIfPresent() throws IOException, InterruptedException {
+    void shouldStoreIfPresent() throws IOException, InterruptedException {
         given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.of(Duration.ofMillis(1)));
         given(build.getExternalizableId()).willReturn("a#1");
 
@@ -58,7 +56,7 @@ public class GlobalTimeOutRunListenerTest {
     }
 
     @Test
-    public void shouldNotStoreIfAbsent() throws IOException, InterruptedException {
+    void shouldNotStoreIfAbsent() throws IOException, InterruptedException {
         given(timeOutProvider.timeOutFor(build, buildListener)).willReturn(Optional.empty());
 
         listener.setUpEnvironment(build, launcher, buildListener);

--- a/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/InMemoryTimeOutStoreTest.java
@@ -1,13 +1,13 @@
 package hudson.plugins.build_timeout.global;
 
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -17,7 +17,7 @@ public class InMemoryTimeOutStoreTest {
     private final TimeOutStore store = new InMemoryTimeOutStore(map);
 
     @Test
-    public void shouldKeep() {
+    void shouldKeep() {
         store.scheduled("a", mock(ScheduledFuture.class));
 
         assertEquals(1, map.size());
@@ -25,7 +25,7 @@ public class InMemoryTimeOutStoreTest {
     }
 
     @Test
-    public void shouldNoOpIfKeyAlreadyExists() {
+    void shouldNoOpIfKeyAlreadyExists() {
         store.scheduled("a", mock(ScheduledFuture.class));
         assertEquals(1, map.size());
 
@@ -35,7 +35,7 @@ public class InMemoryTimeOutStoreTest {
     }
 
     @Test
-    public void shouldRemoveKeyFromMap() {
+    void shouldRemoveKeyFromMap() {
         store.scheduled("a", mock(ScheduledFuture.class));
         store.scheduled("b", mock(ScheduledFuture.class));
 
@@ -46,7 +46,7 @@ public class InMemoryTimeOutStoreTest {
     }
 
     @Test
-    public void shouldCancel() {
+    void shouldCancel() {
         ScheduledFuture<?> a = mock(ScheduledFuture.class);
         ScheduledFuture<?> b = mock(ScheduledFuture.class);
         store.scheduled("a", a);
@@ -59,7 +59,7 @@ public class InMemoryTimeOutStoreTest {
     }
 
     @Test
-    public void shouldNoOpIfAbsent() {
+    void shouldNoOpIfAbsent() {
         store.scheduled("a", mock(ScheduledFuture.class));
         assertEquals(1, map.size());
 

--- a/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/global/TimeOutTaskTest.java
@@ -4,25 +4,22 @@ import com.google.common.collect.Lists;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.plugins.build_timeout.BuildTimeOutOperation;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
-
+import org.mockito.junit.jupiter.MockitoExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
+@ExtendWith(MockitoExtension.class)
 public class TimeOutTaskTest {
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     @Mock
     private TimeOutProvider timeOutProvider;
     @Mock
@@ -31,13 +28,13 @@ public class TimeOutTaskTest {
     private BuildListener listener;
     private TimeOutTask task;
 
-    @Before
+    @BeforeEach
     public void setup() {
         task = TimeOutTask.create(timeOutProvider, build, listener, Duration.ofMillis(1));
     }
 
     @Test
-    public void shouldCallAllOperations() {
+    void shouldCallAllOperations() {
         TestOp one = new TestOp();
         TestOp two = new TestOp();
         given(timeOutProvider.getOperations()).willReturn(Lists.newArrayList(one, two));
@@ -49,7 +46,7 @@ public class TimeOutTaskTest {
     }
 
     @Test
-    public void shouldStopAtFirstFailure() {
+    void shouldStopAtFirstFailure() {
         TestOp one = new TestOp();
         FailsOp two = new FailsOp();
         TestOp three = new TestOp();
@@ -63,7 +60,7 @@ public class TimeOutTaskTest {
     }
 
     @Test
-    public void shouldStopAtFirstException() {
+    void shouldStopAtFirstException() {
         TestOp one = new TestOp();
         ThrowsOp two = new ThrowsOp();
         TestOp three = new TestOp();

--- a/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
@@ -38,10 +38,11 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.BuildTimeoutWrapperIntegrationTest;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -56,20 +57,20 @@ public class AbsoluteTimeOutStrategyTest {
 
     private long origTimeout = 0;
     
-    @Before
+    @BeforeEach
     public void before() {
         // this allows timeout shorter than 3 minutes.
         origTimeout = BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS;
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 1000;
     }
     
-    @After
+    @AfterEach
     public void after() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = origTimeout;
     }
-    
+
     @Test
-    public void configurationWithParameter() throws Exception {
+    void configurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));

--- a/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/AbsoluteTimeOutStrategyTest.java
@@ -38,39 +38,37 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.BuildTimeoutWrapperIntegrationTest;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link AbsoluteTimeOutStrategy}.
  * Many tests for {@link AbsoluteTimeOutStrategy} are also in {@link BuildTimeoutWrapperIntegrationTest}
  */
-public class AbsoluteTimeOutStrategyTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class AbsoluteTimeOutStrategyTest {
 
     private long origTimeout = 0;
     
     @BeforeEach
-    public void before() {
+    void before() {
         // this allows timeout shorter than 3 minutes.
         origTimeout = BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS;
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 1000;
     }
     
     @AfterEach
-    public void after() {
+    void after() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = origTimeout;
     }
 
     @Test
-    void configurationWithParameter() throws Exception {
+    void configurationWithParameter(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));

--- a/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
@@ -40,10 +40,11 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -61,20 +62,20 @@ public class DeadlineTimeOutStrategyTest {
 
     private static final int TOLERANCE_PERIOD_IN_MINUTES = 2;
 
-    @Before
+    @BeforeEach
     public void before() {
         // this allows timeout shorter than 3 minutes.
         origTimeout = BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS;
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 1000;
     }
 
-    @After
+    @AfterEach
     public void after() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = origTimeout;
     }
 
     @Test
-    public void configurationWithParameter() throws Exception {
+    void configurationWithParameter() throws Exception {
         // Deadline in next three seconds. Job should be aborted in three seconds after start
         testWithParam(3, Result.ABORTED);
 

--- a/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/DeadlineTimeOutStrategyTest.java
@@ -40,23 +40,21 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Tests for {@link AbsoluteTimeOutStrategy}. Many tests for
  * {@link AbsoluteTimeOutStrategy} are also in
  * {@link BuildTimeoutWrapperIntegrationTest}
  */
-public class DeadlineTimeOutStrategyTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class DeadlineTimeOutStrategyTest {
 
     private long origTimeout = 0;
 
@@ -75,19 +73,19 @@ public class DeadlineTimeOutStrategyTest {
     }
 
     @Test
-    void configurationWithParameter() throws Exception {
+    void configurationWithParameter(JenkinsRule j) throws Exception {
         // Deadline in next three seconds. Job should be aborted in three seconds after start
-        testWithParam(3, Result.ABORTED);
+        testWithParam(3, Result.ABORTED, j);
 
         // Deadline defined as a past time but inside tolerance period. Job should be aborted immediately
-        testWithParam(-TOLERANCE_PERIOD_IN_MINUTES * 60 / 2, Result.ABORTED);
+        testWithParam(-TOLERANCE_PERIOD_IN_MINUTES * 60 / 2, Result.ABORTED, j);
 
         // Deadline defined as a past time outside tolerance period, so effective deadline will be tomorro. Job should be executed normally.
-        testWithParam(-TOLERANCE_PERIOD_IN_MINUTES * 60 * 2, Result.SUCCESS);
+        testWithParam(-TOLERANCE_PERIOD_IN_MINUTES * 60 * 2, Result.SUCCESS, j);
     }
 
     @SuppressWarnings("deprecation")
-    private void testWithParam(int timeToDeadlineInSecondsFromNow, Result expectedResult) throws Exception {
+    private void testWithParam(int timeToDeadlineInSecondsFromNow, Result expectedResult, JenkinsRule j) throws Exception {
         String deadline = getDeadlineTimeFromNow(timeToDeadlineInSecondsFromNow);
 
         FreeStyleProject p = j.createFreeStyleProject();

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
@@ -39,12 +39,12 @@ import hudson.plugins.build_timeout.BuildTimeOutOperation;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
@@ -52,13 +52,11 @@ import org.htmlunit.html.HtmlPage;
 /**
  * Tests for {@link ElasticTimeOutStrategy} using Jenkins
  */
-public class ElasticTimeOutStrategyJenkinsTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ElasticTimeOutStrategyJenkinsTest {
 
     @Test
-    void canConfigureWithWebPage() throws Exception {
+    void canConfigureWithWebPage(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -97,7 +95,7 @@ public class ElasticTimeOutStrategyJenkinsTest {
     }
 
     @Test
-    void failSafeTimeoutWithVariable() throws Exception {
+    void failSafeTimeoutWithVariable(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FailSafeTimeout", null)));

--- a/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/ElasticTimeOutStrategyJenkinsTest.java
@@ -24,7 +24,7 @@
 
 package hudson.plugins.build_timeout.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
@@ -40,7 +40,8 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
@@ -57,7 +58,7 @@ public class ElasticTimeOutStrategyJenkinsTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void canConfigureWithWebPage() throws Exception {
+    void canConfigureWithWebPage() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -94,9 +95,9 @@ public class ElasticTimeOutStrategyJenkinsTest {
             assertEquals("10", strategy.getNumberOfBuilds());
         }
     }
-    
+
     @Test
-    public void failSafeTimeoutWithVariable() throws Exception {
+    void failSafeTimeoutWithVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FailSafeTimeout", null)));

--- a/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
@@ -33,7 +33,6 @@ import java.util.Date;
 
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
@@ -58,10 +58,8 @@ import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 import hudson.plugins.build_timeout.operations.AbortOperation;
 import hudson.tasks.Builder;
 
-public class NoActivityTimeOutStrategyTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class NoActivityTimeOutStrategyTest {
 
     private long origTimeout = 0;
     
@@ -123,7 +121,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void timeout() throws Exception {
+    void timeout(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new NoActivityTimeOutStrategy(5),
@@ -136,7 +134,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void noTimeout() throws Exception {
+    void noTimeout(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new NoActivityTimeOutStrategy(15),
@@ -161,7 +159,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void performedOnlyOnce() throws Exception {
+    void performedOnlyOnce(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         CountOperation count = new CountOperation();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -177,7 +175,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void canConfigureWithWebPage() throws Exception {
+    void canConfigureWithWebPage(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -214,7 +212,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void canConfigureWithWebPageUsingStringExpression() throws Exception {
+    void canConfigureWithWebPageUsingStringExpression(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -251,7 +249,7 @@ public class NoActivityTimeOutStrategyTest {
     }
 
     @Test
-    void configurationWithParameter() throws Exception {
+    void configurationWithParameter(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));

--- a/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategyTest.java
@@ -24,7 +24,7 @@
 
 package hudson.plugins.build_timeout.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -33,10 +33,11 @@ import java.util.Date;
 
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -64,13 +65,13 @@ public class NoActivityTimeOutStrategyTest {
 
     private long origTimeout = 0;
     
-    @Before
+    @BeforeEach
     public void before() {
         origTimeout = BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS;
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
     }
     
-    @After
+    @AfterEach
     public void after() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = origTimeout;
     }
@@ -120,9 +121,9 @@ public class NoActivityTimeOutStrategyTest {
             return true;
         }
     }
-    
+
     @Test
-    public void timeout() throws Exception {
+    void timeout() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new NoActivityTimeOutStrategy(5),
@@ -133,9 +134,9 @@ public class NoActivityTimeOutStrategyTest {
         
         j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
     }
-    
+
     @Test
-    public void noTimeout() throws Exception {
+    void noTimeout() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                 new NoActivityTimeOutStrategy(15),
@@ -158,9 +159,9 @@ public class NoActivityTimeOutStrategyTest {
         }
         
     }
-    
+
     @Test
-    public void performedOnlyOnce() throws Exception {
+    void performedOnlyOnce() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         CountOperation count = new CountOperation();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
@@ -174,9 +175,9 @@ public class NoActivityTimeOutStrategyTest {
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(1, count.count);
     }
-    
+
     @Test
-    public void canConfigureWithWebPage() throws Exception {
+    void canConfigureWithWebPage() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -211,9 +212,9 @@ public class NoActivityTimeOutStrategyTest {
             assertEquals(60, strategy.getTimeoutSeconds());
         }
     }
-    
+
     @Test
-    public void canConfigureWithWebPageUsingStringExpression() throws Exception {
+    void canConfigureWithWebPageUsingStringExpression() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(
                 new BuildTimeoutWrapper(
@@ -248,9 +249,9 @@ public class NoActivityTimeOutStrategyTest {
             assertEquals(0, strategy.getTimeoutSeconds());
         }
     }
-    
+
     @Test
-    public void configurationWithParameter() throws Exception {
+    void configurationWithParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TIMEOUT", null)));

--- a/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
@@ -31,11 +31,11 @@ import java.util.LinkedList;
 
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
@@ -46,13 +46,11 @@ import hudson.plugins.build_timeout.BuildTimeOutOperation;
 import hudson.plugins.build_timeout.QuickBuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 
-public class AbortAndRestartOperationTest {
+@WithJenkins
+class AbortAndRestartOperationTest {
     
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    void abortAndRestartOnce() throws Exception {
+    void abortAndRestartOnce(JenkinsRule j) throws Exception {
         FreeStyleProject testproject = j.createFreeStyleProject();
 
         QuickBuildTimeOutStrategy strategy = new QuickBuildTimeOutStrategy(5000);
@@ -79,7 +77,7 @@ public class AbortAndRestartOperationTest {
     }
 
     @Test
-    void abortAndRestartTwice() throws Exception {
+    void abortAndRestartTwice(JenkinsRule j) throws Exception {
         FreeStyleProject testproject = j.createFreeStyleProject();
 
         QuickBuildTimeOutStrategy strategy = new QuickBuildTimeOutStrategy(5000);
@@ -108,7 +106,7 @@ public class AbortAndRestartOperationTest {
     }
 
     @Test
-    void usingVariable() throws Exception {
+    void usingVariable(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("RESTART", null)));
@@ -134,7 +132,7 @@ public class AbortAndRestartOperationTest {
     }
 
     @Test
-    void usingBadRestart() throws Exception {
+    void usingBadRestart(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                      new QuickBuildTimeOutStrategy(1000),

--- a/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
@@ -24,10 +24,7 @@
 
 package hudson.plugins.build_timeout.operations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -35,7 +32,8 @@ import java.util.LinkedList;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -54,7 +52,7 @@ public class AbortAndRestartOperationTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void abortAndRestartOnce() throws Exception {
+    void abortAndRestartOnce() throws Exception {
         FreeStyleProject testproject = j.createFreeStyleProject();
 
         QuickBuildTimeOutStrategy strategy = new QuickBuildTimeOutStrategy(5000);
@@ -79,9 +77,9 @@ public class AbortAndRestartOperationTest {
         assertEquals(Result.ABORTED, testproject.getFirstBuild().getResult());
         assertEquals(Result.ABORTED, testproject.getLastBuild().getResult());
     }
-    
+
     @Test
-    public void abortAndRestartTwice() throws Exception {
+    void abortAndRestartTwice() throws Exception {
         FreeStyleProject testproject = j.createFreeStyleProject();
 
         QuickBuildTimeOutStrategy strategy = new QuickBuildTimeOutStrategy(5000);
@@ -108,9 +106,9 @@ public class AbortAndRestartOperationTest {
         assertEquals(Result.ABORTED, testproject.getBuildByNumber(2).getResult());
         assertEquals(Result.ABORTED, testproject.getBuildByNumber(3).getResult());
     }
-    
+
     @Test
-    public void usingVariable() throws Exception {
+    void usingVariable() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("RESTART", null)));
@@ -134,9 +132,9 @@ public class AbortAndRestartOperationTest {
         
         assertEquals(2, p.getBuilds().size());
     }
-    
+
     @Test
-    public void usingBadRestart() throws Exception {
+    void usingBadRestart() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildWrappersList().add(new BuildTimeoutWrapper(
                      new QuickBuildTimeOutStrategy(1000),

--- a/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
@@ -64,7 +64,6 @@ import hudson.tasks.Shell;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,19 +71,18 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 
-public class BuildStepOperationTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class BuildStepOperationTest {
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
     }
     
@@ -123,7 +121,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void disabled() throws Exception {
+    void disabled(JenkinsRule j) throws Exception {
         BuildStepOperation.DescriptorImpl d
             = (BuildStepOperation.DescriptorImpl)j.jenkins.getDescriptorOrDie(BuildStepOperation.class);
         // should be disabled by default.
@@ -133,7 +131,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void enabled() throws Exception {
+    void enabled(JenkinsRule j) throws Exception {
         BuildStepOperation.DescriptorImpl d
             = (BuildStepOperation.DescriptorImpl)j.jenkins.getDescriptorOrDie(BuildStepOperation.class);
         d.setEnabled(true);
@@ -143,7 +141,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void builder() throws Exception {
+    void builder(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -166,7 +164,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void builderFailContinue() throws Exception {
+    void builderFailContinue(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -191,7 +189,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void builderFailStop() throws Exception {
+    void builderFailStop(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -216,7 +214,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void publisher() throws Exception {
+    void publisher(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestPublisher publisher1 = new TestPublisher();
         TestPublisher publisher2 = new TestPublisher();
@@ -239,7 +237,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void configuration() throws Exception {
+    void configuration(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         ArtifactArchiver archiver = new ArtifactArchiver("**/*.xml", "exclude.xml", false);
         
@@ -276,7 +274,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void configurationWithoutDbc() throws Exception {
+    void configurationWithoutDbc(JenkinsRule j) throws Exception {
         final String STRING_TO_TEST = "foobar";
         
         FreeStyleProject p = j.createFreeStyleProject();
@@ -315,7 +313,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void launcher() throws Exception {
+    void launcher(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TESTSTRING", null)));
@@ -347,7 +345,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void noLauncher() throws Exception {
+    void noLauncher(JenkinsRule j) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         
         String TESTSTRING = "***THIS IS OUTPUT IN TIMEOUT***";
@@ -376,7 +374,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    void managePermissionShouldAccess() {
+    void managePermissionShouldAccess(JenkinsRule j) {
         final String USER = "user";
         final String MANAGER = "manager";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());

--- a/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/BuildStepOperationTest.java
@@ -24,7 +24,7 @@
 
 package hudson.plugins.build_timeout.operations;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -64,9 +64,10 @@ import hudson.tasks.Shell;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -82,7 +83,7 @@ public class BuildStepOperationTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
     }
@@ -120,9 +121,9 @@ public class BuildStepOperationTest {
             return result;
         }
     }
-    
+
     @Test
-    public void disabled() throws Exception {
+    void disabled() throws Exception {
         BuildStepOperation.DescriptorImpl d
             = (BuildStepOperation.DescriptorImpl)j.jenkins.getDescriptorOrDie(BuildStepOperation.class);
         // should be disabled by default.
@@ -130,9 +131,9 @@ public class BuildStepOperationTest {
         
         assertFalse(BuildTimeOutOperationDescriptor.all(FreeStyleProject.class).contains(d));
     }
-    
+
     @Test
-    public void enabled() throws Exception {
+    void enabled() throws Exception {
         BuildStepOperation.DescriptorImpl d
             = (BuildStepOperation.DescriptorImpl)j.jenkins.getDescriptorOrDie(BuildStepOperation.class);
         d.setEnabled(true);
@@ -140,9 +141,9 @@ public class BuildStepOperationTest {
         
         assertTrue(BuildTimeOutOperationDescriptor.all(FreeStyleProject.class).contains(d));
     }
-    
+
     @Test
-    public void builder() throws Exception {
+    void builder() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -163,9 +164,9 @@ public class BuildStepOperationTest {
         assertEquals(1, builder1.executed);
         assertEquals(1, builder2.executed);
     }
-    
+
     @Test
-    public void builderFailContinue() throws Exception {
+    void builderFailContinue() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -188,9 +189,9 @@ public class BuildStepOperationTest {
         assertEquals(1, builder1.executed);
         assertEquals(1, builder2.executed);
     }
-    
+
     @Test
-    public void builderFailStop() throws Exception {
+    void builderFailStop() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestBuilder builder1 = new TestBuilder();
         TestBuilder builder2 = new TestBuilder();
@@ -213,9 +214,9 @@ public class BuildStepOperationTest {
         assertEquals(1, builder1.executed);
         assertEquals(0, builder2.executed);
     }
-    
+
     @Test
-    public void publisher() throws Exception {
+    void publisher() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         TestPublisher publisher1 = new TestPublisher();
         TestPublisher publisher2 = new TestPublisher();
@@ -236,9 +237,9 @@ public class BuildStepOperationTest {
         assertEquals(1, publisher1.executed);
         assertEquals(1, publisher2.executed);
     }
-    
+
     @Test
-    public void configuration() throws Exception {
+    void configuration() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         ArtifactArchiver archiver = new ArtifactArchiver("**/*.xml", "exclude.xml", false);
         
@@ -273,9 +274,9 @@ public class BuildStepOperationTest {
         assertEquals("exclude.xml", archiver.getExcludes());
         assertFalse(archiver.isLatestOnly());
     }
-    
+
     @Test
-    public void configurationWithoutDbc() throws Exception {
+    void configurationWithoutDbc() throws Exception {
         final String STRING_TO_TEST = "foobar";
         
         FreeStyleProject p = j.createFreeStyleProject();
@@ -312,9 +313,9 @@ public class BuildStepOperationTest {
         
         assertEquals(STRING_TO_TEST, builder.getDescriptionToSet());
     }
-    
+
     @Test
-    public void launcher() throws Exception {
+    void launcher() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         // needed since Jenkins 2.3
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TESTSTRING", null)));
@@ -344,9 +345,9 @@ public class BuildStepOperationTest {
         ));
         j.assertLogContains(TESTSTRING, p.getLastBuild());
     }
-    
+
     @Test
-    public void noLauncher() throws Exception {
+    void noLauncher() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         
         String TESTSTRING = "***THIS IS OUTPUT IN TIMEOUT***";
@@ -375,7 +376,7 @@ public class BuildStepOperationTest {
     }
 
     @Test
-    public void managePermissionShouldAccess() {
+    void managePermissionShouldAccess() {
         final String USER = "user";
         final String MANAGER = "manager";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -390,12 +391,12 @@ public class BuildStepOperationTest {
 
         try (ACLContext c = ACL.as(User.getById(USER, true))) {
             Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
-            assertTrue("Global configuration should not be accessible to READ users", descriptors.size() == 0);
+            assertTrue(descriptors.size() == 0, "Global configuration should not be accessible to READ users");
         }
         try (ACLContext c = ACL.as(User.getById(MANAGER, true))) {
             Collection<Descriptor> descriptors = Functions.getSortedDescriptorsForGlobalConfigUnclassified();
             Optional<Descriptor> found = descriptors.stream().filter(descriptor -> descriptor instanceof BuildStepOperation.DescriptorImpl).findFirst();
-            assertTrue("Global configuration should be accessible to MANAGE users", found.isPresent());
+            assertTrue(found.isPresent(), "Global configuration should be accessible to MANAGE users");
         }
     }
     

--- a/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
@@ -24,13 +24,14 @@
 
 package hudson.plugins.build_timeout.operations;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -46,13 +47,13 @@ public class WriteDescriptionOperationTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
     }
-    
+
     @Test
-    public void setDescription() throws Exception {
+    void setDescription() throws Exception {
         final String DESCRIPTION = "description to test: {0}, {0}.";
         final String EXPECTED = "description to test: 0, 0.";
         
@@ -71,9 +72,9 @@ public class WriteDescriptionOperationTest {
         
         assertEquals(EXPECTED, b.getDescription());
     }
-    
+
     @Test
-    public void setDescriptionWithoutAborting() throws Exception {
+    void setDescriptionWithoutAborting() throws Exception {
         final String DESCRIPTION = "description to test: {0}, {0}.";
         final String EXPECTED = "description to test: 0, 0.";
         
@@ -91,9 +92,9 @@ public class WriteDescriptionOperationTest {
         
         assertEquals(EXPECTED, b.getDescription());
     }
-    
+
     @Test
-    public void setDescriptionTwice() throws Exception {
+    void setDescriptionTwice() throws Exception {
         final String DESCRIPTION1 = "description to test: {0}, {0}.";
         final String DESCRIPTION2 = "Another message.";
         final String EXPECTED = "Another message.";

--- a/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/WriteDescriptionOperationTest.java
@@ -28,12 +28,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -42,18 +42,16 @@ import hudson.plugins.build_timeout.BuildTimeOutOperation;
 import hudson.plugins.build_timeout.QuickBuildTimeOutStrategy;
 import hudson.plugins.build_timeout.BuildTimeoutWrapper;
 
-public class WriteDescriptionOperationTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class WriteDescriptionOperationTest {
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         BuildTimeoutWrapper.MINIMUM_TIMEOUT_MILLISECONDS = 0;
     }
 
     @Test
-    void setDescription() throws Exception {
+    void setDescription(JenkinsRule j) throws Exception {
         final String DESCRIPTION = "description to test: {0}, {0}.";
         final String EXPECTED = "description to test: 0, 0.";
         
@@ -74,7 +72,7 @@ public class WriteDescriptionOperationTest {
     }
 
     @Test
-    void setDescriptionWithoutAborting() throws Exception {
+    void setDescriptionWithoutAborting(JenkinsRule j) throws Exception {
         final String DESCRIPTION = "description to test: {0}, {0}.";
         final String EXPECTED = "description to test: 0, 0.";
         
@@ -94,7 +92,7 @@ public class WriteDescriptionOperationTest {
     }
 
     @Test
-    void setDescriptionTwice() throws Exception {
+    void setDescriptionTwice(JenkinsRule j) throws Exception {
         final String DESCRIPTION1 = "description to test: {0}, {0}.";
         final String DESCRIPTION2 = "Another message.";
         final String EXPECTED = "Another message.";


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Hi @krisstern!

I saw #85 and thought I'd run it through the [JUnit Jupiter migration from JUnit 4.x](https://docs.openrewrite.org/recipes/java/testing/junit5/junit4to5migration) recipe on [moderne.io](https://moderne.io). This got me most of the way there, then I was able to replace almost all of the `JenkinsRule` integration tests with the JUnit 5 `WithJenkins` annotation.

The one exception is `BuildTimeoutWrapperIntegrationTest`, which is still on JUnit 4 because the `LocalData` annotation on one test does not work with JUnit 5. I think this should be easy to create another way, but didn't want to add too much more to this PR.

### Testing done

Ran `mvn clean verify`.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
