### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 /* For https://ci.jenkins.io/ */
 /* The `buildPlugin` step has been provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 /* For https://ci.jenkins.io/ */
 /* The `buildPlugin` step has been provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
-        <version>1968.vb_14a_29e76128</version>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2496.vddfca_753db_80</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.  

Updates the parent pom and the plugin BOM to most recent releases.

### Test in parallel on ci.jenkins.io

Allow ci.jenkins.io to run the tests with one process per available core, while developers are allowed to configure the amount of parallel testing based on the configuration and use of their computer.

Developers can adjust parallel execution by passing a command line argument to Maven like this:

```bash
mvn clean -DforkCount=1C verify
```

Developers can define a Maven profile that sets the forkCount in their ~/.m2/settings.xml like this:

```xml
<profile>
  <id>faster</id>
  <activation>
    <activeByDefault>true</activeByDefault>
  </activation>
  <properties>
    <forkCount>.45C</forkCount>
  </properties>
</profile>
```

With that entry in the settings.xml file, then 0.45C will be used for:

```bash
mvn clean verify
```

### Testing done

Tests pass with `-DforkCount=1C` on my Linux computer with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
