### PR TITLE
Modernize to Jenkins 2.401.3 with `jakarta.inject`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>4.75</version>
     <relativePath />
   </parent>
 
@@ -34,7 +34,7 @@
   <properties>
     <revision>1.32</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- To be removed once Jenkins.MANAGE permission gets out of beta -->
     <useBeta>true</useBeta>
@@ -61,8 +61,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2496.vddfca_753db_80</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2612.v3d6a_2128c0ef</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutConfiguration.java
@@ -18,7 +18,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutModule.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutModule.java
@@ -5,7 +5,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import hudson.Extension;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.util.HashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/GlobalTimeOutRunListener.java
@@ -6,8 +6,8 @@ import hudson.model.*;
 import hudson.model.listeners.RunListener;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;

--- a/src/main/java/hudson/plugins/build_timeout/global/Lifecycle.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/Lifecycle.java
@@ -3,7 +3,7 @@ package hudson.plugins.build_timeout.global;
 import hudson.Extension;
 import hudson.init.Terminator;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;

--- a/src/main/java/hudson/plugins/build_timeout/global/TimeOut.java
+++ b/src/main/java/hudson/plugins/build_timeout/global/TimeOut.java
@@ -1,6 +1,6 @@
 package hudson.plugins.build_timeout.global;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version.

2.401.2 was the [first version to include Guice 6.x](https://www.jenkins.io/changelog-stable/#v2.401.2), which supports `jakarta.inject`.

## Testing done
Ran `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Refs: sghill-rewrite/campaigns#1 sghill-rewrite/campaigns#2

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin