### PR TITLE
increase the timeout so that the BOM tests pass

### DIFF
--- a/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
+++ b/src/test/java/hudson/plugins/build_timeout/operations/AbortAndRestartOperationTest.java
@@ -94,7 +94,7 @@ class AbortAndRestartOperationTest {
 
         testproject.scheduleBuild(new Cause.UserIdCause());
         
-        j.waitUntilNoActivityUpTo(25000);
+        j.waitUntilNoActivityUpTo(50000);
         
         assertNotNull(testproject.getFirstBuild());
         assertFalse(testproject.getFirstBuild().equals(testproject.getLastBuild()));


### PR DESCRIPTION
This plugin isn't passing with a BOM build since moving to AWS. 

When testing locally, the test:

`mvn clean -Dtest=AbortAndRestartOperationTest verify`

runs fine. However, if I change the timeout from 25 to 23, the local test fails.

My guess is that the AWS infra is running slower than the Azure infra, therefore causing the test to fail during the BOM build.

Also, it sort of makes sense that since the `once` version of the test is 25 seconds, the `twice` version of the test "should be"/"its ok" to be 50 seconds.

### Testing done

* `mvn clean -Dtest=AbortAndRestartOperationTest verify`
* `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue